### PR TITLE
Field import: camp (2026-08-27)

### DIFF
--- a/.agent/work-plans/issue-219/progress.md
+++ b/.agent/work-plans/issue-219/progress.md
@@ -1,0 +1,23 @@
+---
+issue: 219
+---
+
+# Issue #219 — Field import: camp (2026-08-27)
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-09-03 14:22 -04:00
+**By**: Claude Code Agent (Claude Sonnet 5)
+
+**PR**: #220 at `9b4201c`
+**Sources**: 3 (Copilot R1 @ `0fc6408`, Copilot R2 @ `9b4201c`, conversation comment @ 2026-09-03T13:16Z)
+**Cross-source confirmations**: 1
+**CI**: all-pass
+
+### Findings
+- [ ] (cross-confirmed, partially addressed) VOLATILE-durability revert condition recorded at the `.cpp` QoS definition (`9b4201c`) but not at the `.h:48` docstring Copilot specifically flagged — `sonar_live_cache_layer.h`
+- [ ] (open, prior finding) ADR-0010 D5/D7 additions (181 lines, `[field 2026-08-27]`) landed without a dedicated governance read — `docs/decisions/0010-bounded-eviction-overview-pyramid.md`
+- [ ] (valid, Copilot R1) `overviewRebuildChild()` returns `SonarLiveTile` by value on the Qt GUI thread during pyramid rebuild — up to ~3.7 MB/band per surviving child, confirmed against `SonarLiveTile`'s `vector<float>` band storage and the ADR's measured 960×960 tile size; recommend a follow-up issue rather than a blocking fix here — `sonar_live_cache_layer.cpp:1148`
+
+### False positives
+(none)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1174,6 +1174,35 @@ if(BUILD_TESTING)
     ${GDAL_LIBRARY}
   )
 
+  # [field 2026-08-27] Coarse overview data may be drawn ONLY as a placeholder for a
+  # fine tile that is known to exist and has not loaded, clipped to that tile's own
+  # footprint (ADR-0010 D5): nothing coarse while the fine tiles are resident, a
+  # clipped placeholder where one is missing, zoom-out coverage after eviction, and
+  # nothing at all over unsurveyed water. Same offscreen harness (GL-free / ROS-free).
+  ament_add_gtest(test_sonar_live_placeholder_draw
+    test/test_sonar_live_placeholder_draw.cpp
+  )
+  target_include_directories(test_sonar_live_placeholder_draw PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp_map
+  )
+  ament_target_dependencies(test_sonar_live_placeholder_draw
+    geometry_msgs
+    marine_autonomy
+    marine_colormap
+    marine_interfaces
+    marine_tiled_raster_store
+    rclcpp
+    tf2_ros
+  )
+  target_link_libraries(test_sonar_live_placeholder_draw
+    camp_map_ros
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
+
   # [camp#172] On-demand reload of evicted fine tiles (the ADR-0013 hook), with the
   # ADR-0010 D6 hysteresis guard. Same offscreen harness (GL-free / ROS-free).
   ament_add_gtest(test_sonar_live_reload

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1232,6 +1232,32 @@ if(BUILD_TESTING)
     ${GDAL_LIBRARY}
   )
 
+  # [field 2026-08-27] The coverage_catalog subscription QoS must stay VOLATILE to match
+  # the operator-side udp_bridge republisher. No ROS graph / Qt / GL needed.
+  ament_add_gtest(test_sonar_live_catalog_qos
+    test/test_sonar_live_catalog_qos.cpp
+  )
+  target_include_directories(test_sonar_live_catalog_qos PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp_map
+  )
+  ament_target_dependencies(test_sonar_live_catalog_qos
+    geometry_msgs
+    marine_autonomy
+    marine_colormap
+    marine_interfaces
+    marine_tiled_raster_store
+    rclcpp
+    tf2_ros
+  )
+  target_link_libraries(test_sonar_live_catalog_qos
+    camp_map_ros
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
+
   # [camp#170] Tile dimension/byte validation before allocation (crash guard).
   # Same offscreen harness.
   ament_add_gtest(test_sonar_live_tile_validation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1146,6 +1146,34 @@ if(BUILD_TESTING)
     ${GDAL_LIBRARY}
   )
 
+  # [field 2026-08-27] Catalog prune-on-absence must propagate into the derived overview
+  # pyramid (ADR-0010 D7): stale overviews leave memory and disk, ancestors that still
+  # have a catalogued descendant are kept, and one that lost only SOME descendants is
+  # rebuilt from the survivors. Same offscreen harness (GL-free / ROS-free).
+  ament_add_gtest(test_sonar_live_overview_prune
+    test/test_sonar_live_overview_prune.cpp
+  )
+  target_include_directories(test_sonar_live_overview_prune PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/camp_map
+  )
+  ament_target_dependencies(test_sonar_live_overview_prune
+    geometry_msgs
+    marine_autonomy
+    marine_colormap
+    marine_interfaces
+    marine_tiled_raster_store
+    rclcpp
+    tf2_ros
+  )
+  target_link_libraries(test_sonar_live_overview_prune
+    camp_map_ros
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Widgets
+    Qt5::Positioning
+    ${GDAL_LIBRARY}
+  )
+
   # [camp#172] On-demand reload of evicted fine tiles (the ADR-0013 hook), with the
   # ADR-0010 D6 hysteresis guard. Same offscreen harness (GL-free / ROS-free).
   ament_add_gtest(test_sonar_live_reload

--- a/docs/decisions/0010-bounded-eviction-overview-pyramid.md
+++ b/docs/decisions/0010-bounded-eviction-overview-pyramid.md
@@ -296,7 +296,7 @@ Two properties are load-bearing and are pinned by
   removed while a live descendant remains, and only ancestors of something that really
   was withdrawn are rebuilt, so the work is proportionate to what actually went away.
 - **Prune-gate parity.** A `generation_time` of 0 disables prune-on-absence in the
-  reconciler (ADR-0008 D4b: no held version is strictly older than 0), so it disables
+  reconciler (uma ADR-0008 D4, correctness condition (b): no held version is strictly older than 0), so it disables
   the pyramid sweep too. The live set is also unioned with the ancestors of the fine
   tiles still held locally, so a held tile that was absent from the catalog but too
   *new* to prune keeps its ancestors alive.
@@ -361,6 +361,18 @@ rebuild that brings a non-resident overview back into memory is followed by
     warm-load, which is precisely the path that resurrects a stale pyramid.
   - Nightly-regen anti-clobber (a regenerated world store re-publishing a catalog that
     momentarily disagrees with the live one) is untouched by D7 and remains open.
+  - **The Proportionality argument above bounds tile COUNT, not cost per tile.** The
+    sweep and rebuild run on the Qt GUI thread (`handleCatalog` is dispatched
+    `Qt::QueuedConnection`), and on that thread a rebuild performs a synchronous
+    GDAL `loadFromGeoTiff()` per non-resident input, `fs::remove()` per stale
+    overview, and — because `overviewRebuildChild()` returns by value — a copy of
+    each staged/resident child's full band payload (~3.7 MB per 960x960 Float32
+    band). GL texture frees belong on that thread; the disk I/O and the copies do
+    not, and uma ADR-0008 D5 already puts the write-through off the GUI thread for
+    exactly this reason. Unmeasured: the operator-visible cost is unknown, and the
+    likeliest moment to feel it is a reconcile right after a boat-side store reset,
+    which is the case D7 exists to serve. Tracked as camp#224, which asks for a
+    profile before any threading rework.
   - A write-through already in flight for a tile the sweep deletes can still land its
     file after the `remove()`. `cancelPendingWrite()` stops the queued/coalesced case;
     an in-flight worker cannot be cancelled without reintroducing the two-workers-one-

--- a/docs/decisions/0010-bounded-eviction-overview-pyramid.md
+++ b/docs/decisions/0010-bounded-eviction-overview-pyramid.md
@@ -8,6 +8,12 @@ Amended by camp#171/#172 (world-store LOD step 4): D3 reframed as *convergence* 
 the uma shared fold engine (no geometry change); D2 on-demand reload implemented; D6
 reload-hysteresis added. See the "Consequences" memory-math and migration notes.
 
+Amended [field 2026-08-27]: **D5 replaced** — an overview tile is no longer drawn over
+its own extent. Coarse data is drawn only as a *placeholder* for a fine tile that is
+known to exist and has not loaded, clipped to that fine tile's footprint. The old
+draw-order fallback rested on a false premise and put a ~650 m block of folded means
+over the operator's chart mid-survey.
+
 Amended [field 2026-08-27]: **D7** added — catalog prune-on-absence propagates into the
 pyramid. This closes the "overview lifecycle-on-retraction / catalog-prune propagation"
 item that the Consequences list had carried as a deferred follow-up since 2026-08-20.
@@ -90,7 +96,13 @@ discard the rest; viewport centre from `scene()->views()`, LRU by a monotonic
 
 The apex is inherently a small, bounded handful for any realistic survey extent
 (level-6 tiles span ~0.125°), so total resident memory is bounded: fine tiles +
-near-view overviews to the budget, plus the O(small) apex. No vessel-position / tf
+near-view overviews to the budget, plus the O(small) apex.
+
+[field 2026-08-27] What the apex guarantees is unchanged in force but changed in shape
+by D5: it is no longer *drawn* at zoom-out, it is the guaranteed resident **source** a
+zoomed-out view samples through the footprints of the tiles that are missing. Coverage
+still appears everywhere the survey reached; it now stops at the edge of what was
+actually surveyed instead of washing across the apex's own 8° extent. No vessel-position / tf
 dependency — the operator chose view-based LOD over distance-from-vessel as the
 simpler, more natural model.
 
@@ -154,14 +166,72 @@ warm-loaded from the `overviews/` sub-dir (each file's level recovered from its
 stem, since overviews span multiple coarse levels), and are freed under the
 renderer context in the destructor exactly like fine tiles.
 
-### D5 — LOD fallback by draw order
+### D5 — Coarse data is a placeholder for a known missing tile, clipped to its footprint [field 2026-08-27]
 
-`items()` emits overview tiles first (coarse→fine, the natural `std::map` order by
-GGGS level) and the fine tiles last, so the renderer draws fine tiles on top. Where
-a fine tile is present it fully covers its parent; where it was evicted, the coarse
-parent shows through instead of a blank gap. `recomputeBounds()` and
-`foldAutoRange()` union both maps so the extent and colormap range stay correct when
-only overviews remain for a region.
+**Superseded design (what this replaces).** `items()` emitted every resident overview
+first (coarse→fine, the natural `std::map` order by GGGS level) and the fine tiles
+last, so fine drew on top: LOD fallback by draw order alone, with no level selection.
+Its stated premise was "where a fine tile is present it fully covers its parent" —
+**false**: a child covers a *quarter* of its parent. Wherever fine coverage was sparse,
+which is most of a survey in progress, every coarse ancestor painted through. And the
+apex is resident by design (D1), so the coarsest level of all drew at every zoom.
+Measured on pandy during the BizzyBoat deployment: cached tiles are 960×960 cells at
+every level, so a level-0 cell is ~667 × 926 m carrying the MEAN of everything folded
+beneath it. The operator saw a solid ~650 m block over a good part of the survey area,
+covering the chart — over water the survey had never touched.
+
+**The decision.** Coarse data may be drawn **only as a placeholder for a fine tile that
+is known to exist and is not currently resident**, and only **over that fine tile's own
+footprint**. `SonarLiveCacheLayer::planDraw()` resolves exactly two contributions:
+
+1. for each index in `pendingFineIndices()` — known to exist, not resident — the
+   **finest resident ancestor** overview, painted over the *fine index's* extent and
+   sampled through the sub-rect of that ancestor which the index occupies;
+2. every resident fine tile, whole, on top.
+
+Nothing else is drawn. An overview's own extent is never painted, so the pyramid can
+no longer assert coverage over water no fine tile ever covered.
+
+**"Known to exist" is derivable, not guessed.** The boat's catalog is authoritative for
+which tiles exist (`catalogued_fine_`, refreshed from every catalog — a complete
+snapshot, so it is assigned, not merged), and residency is `tiles_`. That set is unioned
+with `evicted_fine_indices_`, which is the only authority available on a warm start with
+no link, and which also covers the window where a catalog has been retracted but the
+disk copy is still ours. The reverse gap is deliberate: a catalogued tile we have never
+received has no disk copy, so it is a *request* candidate (the reconciler's job, ADR-0006
+D4), not a reload candidate — it simply gets a placeholder from whatever the pyramid
+holds over it, which is usually NoData and therefore nothing.
+
+**The clip is a texture sub-rect, not narrowed bounds.** `raster::RasterFieldItem`
+carries a geographic extent and one texture, and the renderer stretches the whole
+texture across the extent — so narrowing the bounds alone would *squash* the coarse tile
+into the small box instead of clipping it. The item therefore gained a normalized
+texture window `[u0,v0]-[u1,v1]` (u west→east, v north→south, texture row 0 = north),
+honoured by `RasterGlRenderer`'s texcoord generation. It **defaults to the whole
+texture**, so `RasterLayer`, `GggsTileLayer` and this layer's own resident tiles emit
+exactly the coordinates they did before. The window is computed from GGGS index
+arithmetic (rows and columns both double per level, and the ±72°/±80°
+`latitudeScaleFactor` bands are bounded by whole grid rows at every level, so an
+ancestor and its descendants always share a band), which makes it an exact
+power-of-two fraction rather than a floating-point extent ratio; a descendant that does
+not resolve inside its ancestor draws nothing rather than guessing a window.
+
+The CPU-side alternative — crop the sub-window into a small per-placeholder texture and
+leave the renderer untouched — was rejected: at zoom-out the pending set is the whole
+survey, so it pays a GPU upload per placeholder per frame (or keeps a second resident
+texture per pending index, which is precisely the memory eviction exists to reclaim).
+The sub-rect samples the textures the pyramid already has.
+
+**No scale threshold, and none needed.** The rule is stated in terms of what is missing,
+not how far out the view is, so the zoom-out case falls out of it: zoomed out over a
+whole survey nearly every catalogued tile is non-resident, so the union of the
+placeholders *is* the coverage. A cell-size-versus-screen-pixel LOD rule was considered
+first and rejected: it would have stopped level 0 from drawing at survey zoom, but at
+any zoom where a coarse level did qualify it would still have smeared that level across
+its full extent, including unsurveyed water.
+
+`recomputeBounds()` and `foldAutoRange()` still union both maps, so the extent and
+colormap range stay correct when only overviews remain for a region.
 
 ### D6 — Reload hysteresis (no ping-pong with eviction)
 
@@ -248,6 +318,17 @@ rebuild that brings a non-resident overview back into memory is followed by
   salmon accelerant) — not just a post-load trim.
 - Evicted coverage degrades gracefully to a coarser resolution rather than vanishing,
   and — with D2/D6 reload — recovers to full resolution when the operator pans back.
+- **[field 2026-08-27] Coarse coverage is now gated on knowing the fine index exists**
+  (D5). Two consequences follow and are accepted. (a) A pyramid whose fine tiles are
+  neither catalogued nor on disk — e.g. `overviews/` warm-loaded after the fine cache
+  was cleared by hand — draws nothing; under the old rule its coarse data would have
+  shown. That is the honest reading: nothing local says that coverage is still real.
+  (b) The number of draw items at zoom-out is now the number of *pending* fine indices
+  rather than the number of overview tiles, so a whole-survey view issues one small quad
+  per missing tile. They share the handful of overview textures (no extra uploads), and
+  the clip culls to the viewport, but a very large survey pays more draw calls than
+  before; batching them (one strip per contiguous run against a shared source) is the
+  obvious lever if it ever bites.
 - **Overview memory converges to the 1.33× series.** Because 4 same-size fine tiles
   collapse into 1 same-size uniform parent (D3), the full pyramid over a densely
   covered region sums to `1 + ¼ + 1/16 + … = 4/3` of one level — eviction frees

--- a/docs/decisions/0010-bounded-eviction-overview-pyramid.md
+++ b/docs/decisions/0010-bounded-eviction-overview-pyramid.md
@@ -8,6 +8,13 @@ Amended by camp#171/#172 (world-store LOD step 4): D3 reframed as *convergence* 
 the uma shared fold engine (no geometry change); D2 on-demand reload implemented; D6
 reload-hysteresis added. See the "Consequences" memory-math and migration notes.
 
+Amended [field 2026-08-27]: **D7** added — catalog prune-on-absence propagates into the
+pyramid. This closes the "overview lifecycle-on-retraction / catalog-prune propagation"
+item that the Consequences list had carried as a deferred follow-up since 2026-08-20.
+It was deferred as bounded and display-grade; the BizzyBoat deployment showed it is
+neither once a boat-side store is reset, because warm-load reinstates the stale pyramid
+on every restart, so no code path could ever reflect the reset.
+
 Cross-reference (camp#195, no change to this decision):
 [ADR-0014](0014-gggs-viewport-scoped-residency.md) gives `GggsTileLayer` its own
 residency budget. It is a **sibling**, not an extension — same forces, different
@@ -182,6 +189,52 @@ amount of local disk I/O, which is the accepted trade for pan-back recovering fu
 resolution. A stronger anti-churn scheme (e.g. a dwell timer before eviction) was judged
 unnecessary at the lake/harbour envelope; revisit if a survey exercises it.
 
+### D7 — Prune-on-absence propagates into the pyramid [field 2026-08-27]
+
+D4 keeps overviews out of the reconciler; it does **not** exempt them from
+prune-on-absence, though the code read as though it did (the `foldIntoParent()` comment
+asserted the exemption as intent). The pyramid is a pure function of the fine tiles, so
+the catalog is authoritative over it too: **an overview tile should exist exactly when
+it is an ancestor of a live fine index.**
+
+`SonarLiveCacheLayer::reconcilePyramid()` runs at the end of every `handleCatalog()`
+reconcile, after the fine prune, and applies two distinct repairs:
+
+- **Stale by absence.** An overview with no live descendant is entirely stale: remove it
+  from `overview_tiles_`, free its GL texture under the renderer's context (the
+  camp#134 discipline the fine prune already follows), and delete its `overviews/` file.
+  The **directory itself is swept**, not just the resident map — eviction phase 1/D2
+  frees an overview Entry while deliberately keeping its disk copy, so a stale overview
+  can be absent from memory and still be warm-loaded back on the next restart. That is
+  exactly how the pre-reset coverage kept returning.
+- **Dirty by partial withdrawal.** An overview that kept some descendants but lost
+  others holds folded contributions that cannot be subtracted: `foldChild()` only ever
+  folds data IN and has no inverse. Such a tile is **rebuilt** from its surviving
+  children rather than kept. The rebuild reproduces the original construction exactly —
+  D3's chain folds the *whole* parent into the grandparent, so every level above the
+  fine tiles is by construction "the fold of my children" — and it draws its inputs from
+  a child repaired earlier in the same pass, else the resident copy, else the disk copy
+  (D2 makes disk the durable backing for both pools). A tile with **no** surviving child
+  is removed instead: a zoomed-out gap is honest, stale coverage is not.
+
+Two properties are load-bearing and are pinned by
+`test/test_sonar_live_overview_prune.cpp`:
+
+- **Proportionality.** Every fine tile's ancestor chain reaches level 0, so invalidating
+  the chain of each pruned tile would destroy the whole pyramid on any ordinary
+  retraction — and tiles are withdrawn and re-added in normal operation. Nothing is
+  removed while a live descendant remains, and only ancestors of something that really
+  was withdrawn are rebuilt, so the work is proportionate to what actually went away.
+- **Prune-gate parity.** A `generation_time` of 0 disables prune-on-absence in the
+  reconciler (ADR-0008 D4b: no held version is strictly older than 0), so it disables
+  the pyramid sweep too. The live set is also unioned with the ancestors of the fine
+  tiles still held locally, so a held tile that was absent from the catalog but too
+  *new* to prune keeps its ancestors alive.
+
+The budget accounting (D1) is unaffected: removals shrink `overviewResidentBytes()`, a
+rebuild that brings a non-resident overview back into memory is followed by
+`evictIfOverBudget()`, and overviews still never enter `reconciler_` (D4 stands).
+
 ## Consequences
 
 - Long surveys no longer grow resident memory/VRAM without bound; the crash scenario
@@ -210,15 +263,28 @@ unnecessary at the lake/harbour envelope; revisit if a survey exercises it.
 - The `LiveTileCache/max_vram_bytes` budget is self-accounted today; when the #155
   `ResourceMonitor` lands, its VRAM feed replaces `accountedBytes()` self-accounting
   behind the same knob (a named integration seam, not in this change).
+- **[field 2026-08-27] Prune now reaches the pyramid** (D7). A retracted region loses its
+  coarse coverage and its `overviews/` files instead of keeping them forever, and a
+  boat-side store reset is reflected on the next catalog rather than never. The costs
+  are accepted and bounded: each catalog reconcile lists the `overviews/` sub-dir
+  (published on change, not at rate), and a repair re-folds only the ancestors of what
+  was actually withdrawn, preferring resident children so the common case does no disk
+  I/O at all.
 - **Deferred follow-ups:**
-  - `handleCatalog` prune removes a retracted fine tile from `tiles_`/disk/reconciler
-    (and now from the reload's evicted-index set) but does not invalidate the overview
-    cells it was folded into, nor delete orphaned `overviews/` files — a retracted
-    region keeps stale coarse coverage and the `overviews/` dir grows slowly. Bounded
-    (overviews are display-grade + evictable). Overview lifecycle-on-retraction /
-    catalog-prune propagation (incl. nightly-regen anti-clobber) is a **tracked
-    follow-up issue**, out of scope for the camp#171/#172 PR (operator decision
-    2026-08-20).
+  - Pyramid content that went stale *before* D7 shipped, in a session whose descendant
+    overviews were already correctly removed, is not detectable: the repair keys off
+    what this reconcile withdrew, and overviews carry no provenance. Not reachable going
+    forward, and not reachable for the state D7 shipped into (the stale `overviews/`
+    files were all still present, so the first reconcile withdrew them and rebuilt their
+    ancestors). Persisting per-overview provenance was rejected — it cannot survive
+    warm-load, which is precisely the path that resurrects a stale pyramid.
+  - Nightly-regen anti-clobber (a regenerated world store re-publishing a catalog that
+    momentarily disagrees with the live one) is untouched by D7 and remains open.
+  - A write-through already in flight for a tile the sweep deletes can still land its
+    file after the `remove()`. `cancelPendingWrite()` stops the queued/coalesced case;
+    an in-flight worker cannot be cancelled without reintroducing the two-workers-one-
+    tmp-path race the coalescing exists to prevent. The next catalog's directory sweep
+    deletes it again, so the window self-heals rather than persisting.
   - `foldChild` silently drops a child cell whose geographic centre falls outside the
     parent (only reachable across a ±72°/±80° GGGS latitude-band boundary) → a possible
     overview seam on a high-latitude survey; add a boundary test / handling if such

--- a/src/camp_map/raster/raster_field_source.h
+++ b/src/camp_map/raster/raster_field_source.h
@@ -51,6 +51,23 @@ struct RasterFieldItem
   /// NaN cells are always discarded by the shader regardless of these.
   bool has_nodata = false;
   float nodata = 0.0f;
+
+  /// [field 2026-08-27] Sub-rect of the texture to stretch across the bounds above,
+  /// in normalized texture coordinates: `u` runs west→east, `v` runs north→south
+  /// (texture row 0 = north, matching the renderer's vertex generation). The
+  /// default (0,0)-(1,1) is the whole texture — exactly what every item did before
+  /// this field existed, so `RasterLayer` and `GggsTileLayer` are unaffected.
+  ///
+  /// It exists for the live-coverage **coarse placeholder**: an overview tile may
+  /// only ever be painted over the footprint of ONE not-yet-loaded fine tile
+  /// (ADR-0010 D5), which is a sub-rectangle of the overview, not the whole of it.
+  /// Narrowing the bounds alone cannot express that — the renderer stretches the
+  /// full texture across whatever bounds it is given, so the coarse tile would be
+  /// squashed into the small box instead of clipped to it.
+  float u0 = 0.0f;   ///< west edge of the sampled sub-rect
+  float v0 = 0.0f;   ///< north edge of the sampled sub-rect
+  float u1 = 1.0f;   ///< east edge of the sampled sub-rect
+  float v1 = 1.0f;   ///< south edge of the sampled sub-rect
 };
 
 /// [camp#134] Per-band metadata, surfaced for the (per-layer) band picker.

--- a/src/camp_map/raster/raster_gl_renderer.cpp
+++ b/src/camp_map/raster/raster_gl_renderer.cpp
@@ -351,13 +351,19 @@ QImage RasterGlRenderer::renderToImage(const QList<RasterFieldItem>& items,
       // already in Web-Mercator metres, so a single linear quad (2 rows) suffices
       // (the RasterLayer path, reprojected by GDAL on load). Interleaved
       // [local_x, local_y, u, v] per vertex; texture row 0 = north (v = 0).
+      // [field 2026-08-27] The texcoords span the item's sub-rect [u0,v0]-[u1,v1]
+      // instead of the whole texture. It DEFAULTS to the whole texture, so every
+      // pre-existing caller (RasterLayer, GggsTileLayer, and the live layer's own
+      // resident tiles) emits exactly the coordinates it did before. The one caller
+      // that narrows it is the live-coverage coarse placeholder, which paints a
+      // single fine tile's footprint out of a coarse overview (ADR-0010 D5).
       const int rows = item.geographic ? (kLatSubdivisions + 1) : 2;
       verts.clear();
       verts.reserve(rows * 2 * 4);
       for(int r = 0; r < rows; ++r)
       {
         const double frac = double(r) / (rows - 1);
-        const float v = float(frac);                   // tex row 0 = north
+        const float v = item.v0 + (item.v1 - item.v0) * float(frac);   // row 0 = north
         QPointF l, rt;
         if(item.geographic)
         {
@@ -373,9 +379,9 @@ QImage RasterGlRenderer::renderToImage(const QList<RasterFieldItem>& items,
           rt = QPointF(item.east, y);
         }
         verts.insert(verts.end(),
-                     {float(l.x() - origin_x), float(l.y() - origin_y), 0.0f, v});
+                     {float(l.x() - origin_x), float(l.y() - origin_y), item.u0, v});
         verts.insert(verts.end(),
-                     {float(rt.x() - origin_x), float(rt.y() - origin_y), 1.0f, v});
+                     {float(rt.x() - origin_x), float(rt.y() - origin_y), item.u1, v});
       }
 
       const bool scalar = (item.format == RasterFieldItem::Format::Scalar);

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
@@ -328,10 +328,24 @@ rclcpp::QoS catalogSubscriptionQos()
   // indefinitely (verified live on pandy: publisher /operator/udp_bridge
   // RELIABLE/VOLATILE vs subscriber /operator/camp RELIABLE/TRANSIENT_LOCAL).
   //
-  // Tradeoff, accepted: volatile means there is no latched sample, so camp no
-  // longer gets the current catalog immediately on join. It must wait for the
-  // next publication of the catalog before it can reconcile. A never-matching
-  // subscription delivers nothing at all, so waiting strictly dominates.
+  // Tradeoff, accepted for now: volatile means there is no latched sample, so
+  // camp no longer gets the current catalog immediately on join. It must wait
+  // for the next publication before it can reconcile -- about 6 s during an
+  // active survey, and UNBOUNDED while the producer is down, which is exactly
+  // the case transient-local exists for. A never-matching subscription
+  // delivers nothing at all, so waiting strictly dominates.
+  //
+  // REVERT THIS TO TRANSIENT_LOCAL once the boat's bridge config is fixed.
+  // Determined after this was written: udp_bridge is NOT at fault and needs no
+  // change. It already supports per-topic transient-local durability (its
+  // doc/qos_design.md, "Durability"); the boat's coverage_catalog entry simply
+  // never set it, so the topic took the documented VOLATILE default. Tracked
+  // as rolker/unh_echoboats_project11#484, which carries the config fix and
+  // lists this revert alongside the same downgrade in marine_web_view.
+  //
+  // Nothing will prompt the revert, which is why it is written here: a
+  // transient-local publisher still MATCHES a volatile subscriber, so once the
+  // config lands camp keeps working and keeps silently losing late-join.
   rclcpp::QoS qos(1);
   qos.durability(rclcpp::DurabilityPolicy::Volatile).reliable();
   return qos;

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <filesystem>
 #include <set>
@@ -127,6 +128,49 @@ QRectF indexSceneRect(const gggs::GridIndex& index)
   const QPointF hi = web_mercator::geoToMap(
     QGeoCoordinate(index.northLatitude(), index.eastLongitude()));
   return QRectF(lo, hi).normalized();
+}
+
+// [field 2026-08-27 / ADR-0010 D5] The sub-rect of @p ancestor's texture that
+// @p descendant occupies, in normalized texture coordinates (u west->east, v
+// north->south — texture row 0 is north, as SonarLiveTile stores it and as the
+// renderer's vertex generation assumes). This is what clips a coarse placeholder to
+// one fine tile's footprint instead of stretching the whole overview over it.
+//
+// Derived from GGGS index arithmetic, not from an extent ratio: a level's grid rows
+// and columns both double per level (the ±72/±80 `latitudeScaleFactor` bands are
+// bounded by whole grid rows at every level, so an ancestor and its descendants are
+// always inside one band and share the scale factor), which makes the window an
+// exact power-of-two fraction — no floating-point extent division, and no drift when
+// the walk spans many levels. Rows count NORTHWARD while v counts southward, hence
+// the row flip.
+//
+// Returns false — caller draws nothing — when @p descendant is not really inside
+// @p ancestor at a finer level. That is the polar-band case the fold itself already
+// declines to handle (ADR-0010's `foldChild` boundary follow-up), and a silent wrong
+// window would paint one tile's data over another's footprint.
+bool textureWindowOf(const gggs::GridIndex& ancestor, const gggs::GridIndex& descendant,
+                     float& u0, float& v0, float& u1, float& v1)
+{
+  if(!ancestor.valid() || !descendant.valid())
+    return false;
+  const int steps = int(descendant.level()) - int(ancestor.level());
+  if(steps <= 0 || steps > 20)   // >20 cannot happen: GGGS has 21 levels
+    return false;
+  const std::uint64_t span = std::uint64_t(1) << steps;
+  const std::uint64_t base_row = std::uint64_t(ancestor.row()) * span;
+  const std::uint64_t base_col = std::uint64_t(ancestor.column()) * span;
+  const std::uint64_t row = descendant.row();
+  const std::uint64_t col = descendant.column();
+  if(row < base_row || row - base_row >= span || col < base_col || col - base_col >= span)
+    return false;
+  const double inv = 1.0 / double(span);
+  const std::uint64_t row_off = row - base_row;
+  const std::uint64_t col_off = col - base_col;
+  u0 = float(double(col_off) * inv);
+  u1 = float(double(col_off + 1) * inv);
+  v0 = float(double(span - 1 - row_off) * inv);   // rows go north, v goes south
+  v1 = float(double(span - row_off) * inv);
+  return true;
 }
 
 // [camp#172] Off-thread reload worker: load each evicted fine tile's cached GeoTIFF
@@ -588,6 +632,21 @@ void SonarLiveCacheLayer::handleCatalog(const marine_interfaces::msg::TileCatalo
   // disableLiveCoverage() (only the tile stream is), so samples keep arriving and
   // landing here throughout a disabled window.
   last_catalog_ = msg;
+
+  // [field 2026-08-27 / ADR-0010 D5] Record what the boat says EXISTS. This is the
+  // set a coarse placeholder may be drawn for (planDraw), so it is maintained from
+  // every catalog — including one that arrives while disabled, exactly like the
+  // camp#169 buffer above, since a re-enable replays that buffer rather than
+  // waiting for a catalog that may not be republished for the rest of the session.
+  // A complete catalog is a full snapshot, so this is an assignment, not a merge:
+  // a tile that left the catalog must stop being placeholder-able at once.
+  catalogued_fine_.clear();
+  for(const auto& entry : msg.entries)
+  {
+    const gggs::GridIndex index = gridIndexFromTileIndex(entry.index);
+    if(index.valid())
+      catalogued_fine_.insert(index);
+  }
 
   if(!enabled_)
   {
@@ -1215,8 +1274,14 @@ bool SonarLiveCacheLayer::hasUnloadedVisibleTiles(const QRectF& viewport_scene) 
 {
   // [camp#172 / ADR-0013] Does the viewport expose an evicted fine tile whose disk copy
   // is not resident? GUI thread. The tile is gone, so test the GGGS extent of the index
-  // directly (same extent math as itemsIntersecting's per-tile clip test). A null
+  // directly (indexSceneRect — literally the clip test planDraw() applies). A null
   // viewport (headless with no clip) matches nothing — reload is viewport-driven.
+  // [field 2026-08-27] Consistent with the draw set by construction: every index here is
+  // in pendingFineIndices() (evicted, so not resident), i.e. every tile this wants to
+  // reload is one currently shown as a coarse placeholder, and a completed reload
+  // replaces that placeholder with the real thing. The converse does not hold and must
+  // not: a catalogued tile we have never received is placeholder-able but has no disk
+  // copy to reload — it is a REQUEST candidate (the reconciler's job), not a reload one.
   if(viewport_scene.isNull())
     return false;
   for(const gggs::GridIndex& index : evicted_fine_indices_)
@@ -1521,6 +1586,114 @@ QPair<float, float> SonarLiveCacheLayer::dataRange() const
   return {float(data_min_), float(data_max_)};
 }
 
+std::set<gggs::GridIndex> SonarLiveCacheLayer::pendingFineIndices() const
+{
+  // [field 2026-08-27 / ADR-0010 D5] The fine tiles KNOWN TO EXIST that are not
+  // resident. Coarse overview data may be drawn for exactly these indices and for
+  // nothing else, so this set is the whole licence for painting anything coarse.
+  //
+  // Two authorities are unioned because neither alone is complete:
+  //   * the catalog is authoritative for what exists on the boat, but it is empty
+  //     until the first one arrives (a warm start with the link down never sees
+  //     one, yet the disk cache is full of real coverage);
+  //   * evicted_fine_indices_ is locally known — an evicted tile whose disk copy
+  //     survives — but it is CLEARED after a reload attempt whether or not the
+  //     load succeeded (camp#172, so a permanently unloadable index cannot re-kick
+  //     forever), which would otherwise silently blank a region the catalog still
+  //     lists.
+  // A resident index is excluded: it draws itself at full resolution, and a
+  // placeholder under it would be a coarse wash bleeding past its edges.
+  std::set<gggs::GridIndex> pending;
+  for(const gggs::GridIndex& index : catalogued_fine_)
+    if(!tiles_.count(index))
+      pending.insert(index);
+  for(const gggs::GridIndex& index : evicted_fine_indices_)
+    if(!tiles_.count(index))
+      pending.insert(index);
+  return pending;
+}
+
+const SonarLiveCacheLayer::Entry* SonarLiveCacheLayer::finestResidentAncestor(
+  const gggs::GridIndex& index, gggs::GridIndex* source) const
+{
+  // [field 2026-08-27] Walk up the GGGS chain and stop at the first resident
+  // overview: the finest coarse representation this pyramid holds for @p index.
+  // Nothing resident anywhere up the chain means the pyramid has no data over it,
+  // so the caller draws nothing — an honest gap beats inventing coverage.
+  for(gggs::GridIndex a = gggs::parent(index); a.valid(); a = gggs::parent(a))
+  {
+    auto it = overview_tiles_.find(a);
+    if(it != overview_tiles_.end())
+    {
+      if(source)
+        *source = a;
+      return &it->second;
+    }
+  }
+  return nullptr;
+}
+
+std::vector<SonarLiveCacheLayer::DrawItem> SonarLiveCacheLayer::planDraw(
+  const QRectF& clip_scene) const
+{
+  // [field 2026-08-27 / ADR-0010 D5] Resolve the draw list. Two contributions, and
+  // deliberately no third:
+  //
+  //   1. a COARSE PLACEHOLDER for every fine tile that is known to exist but has
+  //      not loaded (pendingFineIndices()), sampled out of its finest resident
+  //      ancestor and clipped — via the texture sub-rect — to that fine tile's own
+  //      footprint;
+  //   2. every RESIDENT fine tile, whole, on top.
+  //
+  // What is NOT drawn is the point of this function. An overview tile used to be
+  // drawn over its own extent, which is 4^n fine tiles wide: at level 0 a single
+  // cell is ~667 x 926 m of the mean of everything folded beneath it, painted
+  // across water nobody has ever surveyed and over the chart underneath. The
+  // premise that licensed it — "where a fine tile is present it fully covers its
+  // parent" (camp#160) — is false: a child covers a QUARTER of its parent, so the
+  // parent showed through everywhere the finer level was sparse, which is most of
+  // a survey in progress. Measured on pandy during the BizzyBoat deployment: the
+  // operator saw a solid ~650 m block over a good part of the survey area.
+  //
+  // Scale does not appear here at all. A placeholder exists exactly while a real
+  // tile is missing, so the zoomed-out case needs no separate threshold: zoom out
+  // over a whole survey and nearly every catalogued tile is non-resident, so the
+  // union of their footprints IS the coverage (ADR-0010 D1).
+  //
+  // [camp#103] A non-null @p clip_scene culls by Web-Mercator extent here, before
+  // any texture is touched, so an offscreen tile is neither uploaded nor drawn.
+  std::vector<DrawItem> plan;
+  const bool clipped = !clip_scene.isNull();
+
+  for(const gggs::GridIndex& index : pendingFineIndices())
+  {
+    if(clipped && !indexSceneRect(index).intersects(clip_scene))
+      continue;
+    gggs::GridIndex source;
+    const Entry* ancestor = finestResidentAncestor(index, &source);
+    if(!ancestor)
+      continue;
+    DrawItem item;
+    item.footprint = index;
+    item.source = source;
+    item.placeholder = true;
+    if(!textureWindowOf(source, index, item.u0, item.v0, item.u1, item.v1))
+      continue;   // not a real descendant (see textureWindowOf) — draw nothing
+    plan.push_back(item);
+  }
+
+  for(const auto& entry : tiles_)
+  {
+    if(clipped && !indexSceneRect(entry.first).intersects(clip_scene))
+      continue;
+    DrawItem item;
+    item.footprint = entry.first;
+    item.source = entry.first;
+    plan.push_back(item);
+  }
+  return plan;
+}
+
 QList<raster::RasterFieldItem> SonarLiveCacheLayer::items()
 {
   return itemsIntersecting(QRectF());
@@ -1529,53 +1702,48 @@ QList<raster::RasterFieldItem> SonarLiveCacheLayer::items()
 QList<raster::RasterFieldItem> SonarLiveCacheLayer::itemsIntersecting(
   const QRectF& clip_scene)
 {
-  // [camp#134] Collect the held tiles' selected band as Scalar items for the shared
+  // [camp#134] Turn planDraw()'s selection into Scalar items for the shared
   // renderer. Called with the renderer's GL context current (renderImage()), so
   // textureFor() may lazily (re)upload here. The geo->Web-Mercator warp lives in
-  // the renderer; this only forwards each tile's lat/lon extent + NoData sentinel.
-  // [camp#103] A non-null @p clip_scene keeps only tiles whose Web-Mercator extent
-  // intersects it — tested BEFORE textureFor(), so offscreen tiles are neither
-  // uploaded nor drawn. Both pools are filtered with the same predicate, keeping
-  // the overviews-first order below intact.
+  // the renderer; this only forwards each footprint's lat/lon extent, the sampled
+  // texture sub-rect, and the source tile's NoData sentinel.
+  // [camp#103] The clip test already happened in planDraw(), i.e. BEFORE
+  // textureFor(), so an offscreen tile is still neither uploaded nor drawn.
+  const std::vector<DrawItem> plan = planDraw(clip_scene);
   QList<raster::RasterFieldItem> result;
-  result.reserve(int(overview_tiles_.size() + tiles_.size()));
-  auto append = [&](Entry& entry)
+  result.reserve(int(plan.size()));
+  for(const DrawItem& planned : plan)
   {
-    if(!clip_scene.isNull())
-    {
-      const QPointF lo = web_mercator::geoToMap(
-        QGeoCoordinate(entry.tile.minLat(), entry.tile.minLon()));
-      const QPointF hi = web_mercator::geoToMap(
-        QGeoCoordinate(entry.tile.maxLat(), entry.tile.maxLon()));
-      if(!QRectF(lo, hi).normalized().intersects(clip_scene))
-        return;
-    }
+    auto& pool = planned.placeholder ? overview_tiles_ : tiles_;
+    auto it = pool.find(planned.source);
+    if(it == pool.end())
+      continue;
+    Entry& entry = it->second;
     const SonarLiveBand* band = entry.tile.band(band_name_);
     if(!band)
-      return;
+      continue;
     QOpenGLTexture* texture = textureFor(entry);
     if(!texture)
-      return;
+      continue;
     raster::RasterFieldItem fi;
     fi.texture = texture;
     fi.format = raster::RasterFieldItem::Format::Scalar;
     fi.geographic = true;
-    fi.west = entry.tile.minLon();
-    fi.east = entry.tile.maxLon();
-    fi.south = entry.tile.minLat();
-    fi.north = entry.tile.maxLat();
+    // The extent painted is the FOOTPRINT's, not the source tile's: for a coarse
+    // placeholder they differ, and the sub-rect below is what keeps the coarse
+    // texture clipped to it instead of being squashed across it.
+    fi.west = planned.footprint.westLongitude();
+    fi.east = planned.footprint.eastLongitude();
+    fi.south = planned.footprint.southLatitude();
+    fi.north = planned.footprint.northLatitude();
+    fi.u0 = planned.u0;
+    fi.v0 = planned.v0;
+    fi.u1 = planned.u1;
+    fi.v1 = planned.v1;
     fi.has_nodata = band->has_nodata;
     fi.nodata = band->has_nodata ? band->nodata : 0.0f;
     result.push_back(fi);
-  };
-  // [camp#160] LOD fallback by draw order: overviews first (coarse->fine, the
-  // std::map orders by GGGS level), then the fine tiles on top. Where a fine tile
-  // is present it fully covers its parent; where it was evicted, the coarse parent
-  // shows through instead of a blank gap.
-  for(auto& item : overview_tiles_)
-    append(item.second);
-  for(auto& item : tiles_)
-    append(item.second);
+  }
   return result;
 }
 
@@ -1593,8 +1761,8 @@ QImage SonarLiveCacheLayer::renderImage(const QSize& size, const QRectF& clip_bo
   // (uploading textures under it), then delegate the warp + draw.
   if(!renderer_.makeCurrent())
     return QImage();
-  // [camp#103] Only tiles intersecting the clip contribute (both pools,
-  // overviews-first order preserved — the ADR-0010 LOD fallback).
+  // [camp#103] Only what intersects the clip contributes: the resident fine tiles
+  // plus a coarse placeholder for each known-but-not-loaded one (ADR-0010 D5).
   const QList<raster::RasterFieldItem> draw = itemsIntersecting(clip_bounds);
   // [camp#142] Feed the resolved range (Auto tracks data_min_/data_max_; Manual is
   // the operator override) into the shader's u_min/u_max instead of the raw extents.

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
@@ -227,14 +227,34 @@ QString SonarLiveCacheLayer::settingsKey() const
 
 // ------------------------------- subscriptions -------------------------------
 
+rclcpp::QoS catalogSubscriptionQos()
+{
+  // Complete snapshot, latest wins: reliable, depth 1.
+  //
+  // [field 2026-08-27] Durability must be VOLATILE, not transient-local. The boat-side
+  // producer IS transient-local, but camp runs on the OPERATOR side and never
+  // sees that publisher: it receives the catalog as republished by
+  // `udp_bridge`, which emits VOLATILE. A transient-local subscriber is
+  // QoS-incompatible with a volatile publisher, so the subscription never
+  // matched and handleCatalog() never fired — the anti-entropy reconcile
+  // (ADR-0006 D4) never pruned, and stale coverage persisted on screen
+  // indefinitely (verified live on pandy: publisher /operator/udp_bridge
+  // RELIABLE/VOLATILE vs subscriber /operator/camp RELIABLE/TRANSIENT_LOCAL).
+  //
+  // Tradeoff, accepted: volatile means there is no latched sample, so camp no
+  // longer gets the current catalog immediately on join. It must wait for the
+  // next publication of the catalog before it can reconcile. A never-matching
+  // subscription delivers nothing at all, so waiting strictly dominates.
+  rclcpp::QoS qos(1);
+  qos.durability(rclcpp::DurabilityPolicy::Volatile).reliable();
+  return qos;
+}
+
 void SonarLiveCacheLayer::subscribeCatalog()
 {
   if(catalog_sub_ || !node_ || !node_->node())
     return;
-  // Complete snapshot, latest wins; transient-local so a late joiner gets the
-  // current catalog immediately (matches the boat-side producer QoS).
-  rclcpp::QoS qos(1);
-  qos.transient_local().reliable();
+  const rclcpp::QoS qos = catalogSubscriptionQos();
   const std::string topic = base_namespace_ + "/coverage_catalog";
   catalog_sub_ = node_->node()->create_subscription<marine_interfaces::msg::TileCatalog>(
     topic, qos,
@@ -306,7 +326,7 @@ void SonarLiveCacheLayer::enableLiveCoverage()
   warmLoad();
   subscribeTiles();
   // [camp#169] Replay the buffered catalog so reconcile (and the resulting tile
-  // requests) fire on every enable — the latched sample may have arrived while
+  // requests) fire on every enable — the sample may have arrived while
   // disabled (startup settings-restore race) or the request publisher may have
   // been torn down by a disable since the last reconcile. Direct call on the
   // GUI thread; enabled_ is already true so handleCatalog() proceeds. Warm-load
@@ -514,10 +534,16 @@ void SonarLiveCacheLayer::handleCatalog(const marine_interfaces::msg::TileCatalo
   if(!level_ && !msg.entries.empty())
     level_ = msg.entries.front().index.level;
 
-  // [camp#169] Always buffer, even while disabled: the transient-local depth-1
-  // subscription delivers its latched sample exactly once — discarding it here
-  // while disabled means no reconcile ever fires (the boat's catalog is stable,
-  // so nothing re-delivers it). enableLiveCoverage() replays this buffer.
+  // [camp#169] Always buffer, even while disabled. The catalog is published only
+  // when it changes, and the boat's catalog is stable for long stretches, so a
+  // sample discarded here while disabled may not be re-delivered for the rest of
+  // the session — no reconcile would ever fire. enableLiveCoverage() replays this
+  // buffer. [field 2026-08-27] The volatile subscription makes this MORE load-bearing, not
+  // less: there is no latched sample to re-deliver on a late join either, so this
+  // buffer is now the only path from a catalog seen while disabled to a reconcile
+  // on enable. The catalog subscription itself is never torn down by
+  // disableLiveCoverage() (only the tile stream is), so samples keep arriving and
+  // landing here throughout a disabled window.
   last_catalog_ = msg;
 
   if(!enabled_)

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.cpp
@@ -26,7 +26,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <filesystem>
+#include <set>
 #include <vector>
 
 namespace camp
@@ -55,6 +57,53 @@ QString sanitize(const std::string& ns)
 // [camp#160] Cache sub-directory for overview pyramid tiles, kept apart from the
 // fine tiles at the cache-dir root so warm-load of fine tiles can't pick them up.
 const std::string kOverviewSubdir = "overviews";
+
+// [field 2026-08-27] The cache filename stem for a tile index, `<level>_<row>_<col>` —
+// the single formula behind every cache path (fine tiles at the cache-dir root,
+// overviews under `overviews/`). It was open-coded at three sites; the pyramid prune
+// adds more, and a silent divergence between the writer's name and a deleter's name
+// would orphan files rather than fail loudly.
+std::string tileStem(const gggs::GridIndex& index)
+{
+  return std::to_string(static_cast<int>(index.level())) + "_" +
+         std::to_string(index.row()) + "_" + std::to_string(index.column());
+}
+
+// [field 2026-08-27] Cache path of a fine tile (cache-dir root) and of an overview tile
+// (the `overviews/` sidecar sub-dir).
+std::filesystem::path fineTilePath(const std::string& cache_dir, const gggs::GridIndex& index)
+{
+  return std::filesystem::path(cache_dir) / (tileStem(index) + ".tif");
+}
+
+std::filesystem::path overviewTilePath(const std::string& cache_dir,
+                                       const gggs::GridIndex& index)
+{
+  return std::filesystem::path(cache_dir) / kOverviewSubdir / (tileStem(index) + ".tif");
+}
+
+// [field 2026-08-27] Inverse of tileStem(): recover a GridIndex from a cache filename
+// stem. Returns the invalid sentinel when the stem does not parse in full or does not
+// name a real grid — the disk sweep then leaves that file alone rather than guessing,
+// since writeTileToCache() is the only writer and only ever emits this shape.
+gggs::GridIndex indexFromStem(const std::string& stem)
+{
+  int level = 0;
+  unsigned long long row = 0;
+  unsigned long long col = 0;
+  int consumed = 0;
+  if(std::sscanf(stem.c_str(), "%d_%llu_%llu%n", &level, &row, &col, &consumed) != 3 ||
+     consumed != static_cast<int>(stem.size()))
+    return gggs::GridIndex();
+  if(level < 0 || level > 255 ||
+     row > 0xffffffffull || col > 0xffffffffull)
+    return gggs::GridIndex();
+  marine_interfaces::msg::TileIndex wire;
+  wire.level = static_cast<std::uint8_t>(level);
+  wire.row = static_cast<std::uint32_t>(row);
+  wire.col = static_cast<std::uint32_t>(col);
+  return gridIndexFromTileIndex(wire);
+}
 
 // [camp#160] Squared distance (Web-Mercator scene units) from a tile's centre to
 // a scene point — the eviction key for view-based LOD (farthest tile evicts first).
@@ -110,10 +159,7 @@ std::vector<SonarLiveTile> reloadTilesFromCache(std::vector<gggs::GridIndex> ind
   loaded.reserve(indices.size());
   for(const gggs::GridIndex& index : indices)
   {
-    const std::string stem = std::to_string(static_cast<int>(index.level())) + "_" +
-                             std::to_string(index.row()) + "_" +
-                             std::to_string(index.column()) + ".tif";
-    const std::string path = (fs::path(dir) / stem).string();
+    const std::string path = (fs::path(dir) / (tileStem(index) + ".tif")).string();
     auto tile = SonarLiveTile::loadFromGeoTiff(path, level);
     if(tile && tile->index().valid())
       loaded.push_back(std::move(*tile));
@@ -138,10 +184,7 @@ void writeTileToCache(SonarLiveTile tile, std::string dir)
   fs::create_directories(dir, ec);
   if(ec)
     return;   // unwritable cache dir — skip the GDAL round-trip (best-effort cache)
-  const std::string stem = std::to_string(static_cast<int>(tile.index().level())) + "_" +
-                           std::to_string(tile.index().row()) + "_" +
-                           std::to_string(tile.index().column());
-  const std::string final_path = (fs::path(dir) / (stem + ".tif")).string();
+  const std::string final_path = (fs::path(dir) / (tileStem(tile.index()) + ".tif")).string();
   const std::string tmp_path = final_path + ".tmp";
   if(!tile.writeToGeoTiff(tmp_path))
   {
@@ -579,13 +622,13 @@ void SonarLiveCacheLayer::handleCatalog(const marine_interfaces::msg::TileCatalo
       tiles_.erase(it);
       pruned = true;
     }
-    // Delete the disk copy too (best-effort).
+    // Delete the disk copy too (best-effort). [field 2026-08-27] Drop the queued
+    // write-through first, or a coalesced relaunch would re-create the file we are
+    // about to remove (see cancelPendingWrite for the in-flight case).
+    cancelPendingWrite(index);
     namespace fs = std::filesystem;
-    const std::string stem = std::to_string(static_cast<int>(index.level())) + "_" +
-                             std::to_string(index.row()) + "_" +
-                             std::to_string(index.column()) + ".tif";
     std::error_code ec;
-    fs::remove(fs::path(cache_dir_) / stem, ec);
+    fs::remove(fineTilePath(cache_dir_, index), ec);
     // [camp#172] The disk copy is gone, so this index is no longer reloadable — drop
     // it from the on-demand reload set, or kickReload() would snapshot it and
     // loadFromGeoTiff() would fail forever with the index never cleared.
@@ -594,7 +637,18 @@ void SonarLiveCacheLayer::handleCatalog(const marine_interfaces::msg::TileCatalo
   }
   if(gl_current)
     renderer_.doneCurrent();
-  if(pruned)
+
+  // [field 2026-08-27] Propagate prune-on-absence into the DERIVED overview pyramid
+  // (ADR-0010 D7). Pruning only `tiles_` leaves the folded coarse copy of a retracted
+  // region on screen and on disk forever — it is warm-loaded back on every restart, so
+  // no code path could ever reflect a boat-side store reset (measured on pandy: fine
+  // tiles pruned 107M -> 44M while 41M of `overviews/` survived and kept the pre-reset
+  // coverage in front of the operator).
+  const bool pyramid_changed = reconcilePyramid(catalog, result.to_prune);
+  if(pyramid_changed)
+    evictIfOverBudget();   // a rebuild can pull a non-resident overview back into memory
+
+  if(pruned || pyramid_changed)
   {
     // Reset before re-folding so a pruned tile's extreme min/max can't linger in
     // data_min_/data_max_ — the range reflects only the surviving tiles (mirrors
@@ -663,6 +717,30 @@ void SonarLiveCacheLayer::onWriteThroughFinished(const gggs::GridIndex& index,
     write_states_.erase(it);    // clean: drop the per-tile state
 }
 
+void SonarLiveCacheLayer::cancelPendingWrite(const gggs::GridIndex& index)
+{
+  // [field 2026-08-27] GUI thread. The tile is being deleted, so drop its queued
+  // write-through — without this a coalesced relaunch would re-create the `.tif` the
+  // caller is about to remove, and warm-load would resurrect the deleted tile on the
+  // next restart.
+  //
+  // An IN-FLIGHT write cannot be cancelled, and its WriteState must NOT be erased:
+  // scheduleWriteThrough() keys "is a worker already running for this index?" on that
+  // state, so erasing it would let a later fold launch a SECOND concurrent worker
+  // racing the first on the shared `<stem>.tif.tmp` path — the exact bug the
+  // coalescing exists to prevent. Clear `dirty` instead and let
+  // onWriteThroughFinished() erase the state. The already-running worker may still
+  // land its file after the caller's remove(); the next catalog's pyramid sweep scans
+  // the directory and deletes it again, so that window self-heals rather than
+  // persisting.
+  auto it = write_states_.find(index);
+  if(it == write_states_.end())
+    return;
+  it->second.dirty = false;
+  if(!it->second.in_flight)
+    write_states_.erase(it);
+}
+
 // -------------------------- eviction / overview pyramid ----------------------
 
 std::size_t SonarLiveCacheLayer::entryBytes(const Entry& e)
@@ -728,8 +806,19 @@ void SonarLiveCacheLayer::foldIntoParent(const SonarLiveTile& fine)
   // camp#171). foldChild() requires parent and child to be the same size (it maps each
   // child into a 1/4 sub-window), so the parent MUST match fine.width()/height(). They
   // persist under the `overviews/` cache sub-dir (the uma sidecar layout) and are never
-  // added to the reconciler (a local derived product; prune-on-absence must not touch
-  // them).
+  // added to the reconciler (ADR-0010 D4: they are a local derived product and are not
+  // in the boat's catalog, so reconciling them directly would prune them all on the
+  // first catalog).
+  //
+  // [field 2026-08-27] That is a statement about the RECONCILER's membership, not an
+  // exemption from prune-on-absence, and this comment used to assert the latter. It was
+  // wrong, and the bug it described as intent shipped: a retracted region kept its
+  // coarse coverage forever. The pyramid is derived from the fine tiles, so the catalog
+  // is authoritative over it too — see reconcilePyramid(), which removes overviews with
+  // no catalogued descendant and REBUILDS the ones that merely lost some. The rebuild is
+  // the other half of the reason: this fold is purely accumulative (foldChild only ever
+  // folds data IN — there is no un-fold), so a withdrawn contribution can never be
+  // subtracted from a parent in place.
   const gggs::GridIndex parent_index = gggs::parent(fine.index());
   if(!parent_index.valid())
     return;
@@ -745,6 +834,269 @@ void SonarLiveCacheLayer::foldIntoParent(const SonarLiveTile& fine)
   overview.texture_dirty = true;
   scheduleWriteThrough(overview.tile, kOverviewSubdir);
   foldIntoParent(overview.tile);   // build the full chain to level 0
+}
+
+// ------------------- pyramid prune-on-absence (ADR-0010 D7) ------------------
+
+bool SonarLiveCacheLayer::reconcilePyramid(
+  const marine_tiled_raster_store::TileCatalog& catalog,
+  const std::vector<gggs::GridIndex>& pruned_fine)
+{
+  // [field 2026-08-27] Converge the DERIVED overview pyramid to the catalog, the same
+  // way handleCatalog() converges the fine tiles. The pyramid is a function of the fine
+  // tiles, so the catalog is authoritative over it too — an overview tile SHOULD exist
+  // exactly when it is an ancestor of a live fine index.
+  //
+  // Two distinct failure modes, two distinct repairs:
+  //   * stale by absence   — no live descendant at all: the whole tile is stale, remove
+  //                          it (memory + GPU texture + disk).
+  //   * dirty by partial   — some descendants live, but a descendant was withdrawn:
+  //     withdrawal            foldChild() has no inverse, so the withdrawn contribution
+  //                          cannot be subtracted in place. Rebuild the tile from its
+  //                          surviving children instead of keeping it.
+  //
+  // Deliberately NOT done: invalidating the whole ancestor chain of every pruned tile.
+  // That chain always reaches level 0, which spans a whole GGGS grid at the coarsest
+  // level, so any single ordinary retraction would destroy the apex — and tiles are
+  // withdrawn and re-added in normal operation. The work here is proportionate to what
+  // actually went away: nothing is removed while a live descendant remains, and only
+  // ancestors of something that really was withdrawn are rebuilt.
+  namespace fs = std::filesystem;
+  std::error_code ec;
+
+  // Prune-gate parity with the reconciler (ADR-0008 D4b): a generation_time of 0 — an
+  // un-stamped or sim-time-0 catalog — disables prune-on-absence there, because no held
+  // version can be strictly older than 0. It must disable it here too, or an unstamped
+  // catalog would sweep the entire pyramid while every fine tile stayed put.
+  if(catalog.generation_time == 0)
+    return false;
+
+  // ---- 1. The authoritative live-ancestor set --------------------------------
+  // Ancestors of every catalogued fine index, unioned with the ancestors of the fine
+  // tiles we still possess locally. The second half is what keeps this consistent with
+  // the reconciler's per-tile timestamp gate: a held fine tile that is absent from the
+  // catalog but too NEW to prune is still on disk and still legitimately folded into
+  // its ancestors, so those ancestors must not be swept out from under it. Walking each
+  // chain only until it meets an already-recorded ancestor keeps this linear in the
+  // size of the result, not catalog-size x pyramid-depth.
+  std::set<gggs::GridIndex> live;
+  auto addChain = [&live](const gggs::GridIndex& index)
+  {
+    for(gggs::GridIndex a = gggs::parent(index); a.valid(); a = gggs::parent(a))
+      if(!live.insert(a).second)
+        break;
+  };
+  for(const auto& entry : catalog.entries)
+    addChain(entry.index);
+  for(const auto& item : tiles_)                              // post-prune residency
+    addChain(item.first);
+  for(const gggs::GridIndex& index : evicted_fine_indices_)   // post-prune, on disk
+    addChain(index);
+
+  // ---- 2. Stale by absence ---------------------------------------------------
+  std::set<gggs::GridIndex> gone;
+  for(const auto& item : overview_tiles_)
+    if(!live.count(item.first))
+      gone.insert(item.first);
+
+  // The `overviews/` sub-dir must be swept too, not just the resident map. Memory-
+  // pressure eviction (evictIfOverBudget phase 2) frees an overview Entry but KEEPS its
+  // disk copy on purpose — the disk cache is the durable backing (ADR-0010 D2) — so a
+  // stale overview can be invisible in overview_tiles_ and still be warm-loaded back on
+  // the next restart. That is precisely how the pre-reset coverage kept returning on
+  // pandy. Collect first, delete after: removing entries under a live
+  // directory_iterator is not defined.
+  std::vector<fs::path> stale_files;
+  for(fs::directory_iterator it(fs::path(cache_dir_) / kOverviewSubdir, ec), end;
+      !ec && it != end; it.increment(ec))
+  {
+    if(it->path().extension() != ".tif")
+      continue;
+    const gggs::GridIndex index = indexFromStem(it->path().stem().string());
+    if(!index.valid() || live.count(index))
+      continue;
+    stale_files.push_back(it->path());
+    gone.insert(index);
+  }
+  // Delete the stale files BEFORE the rebuild below reads children off disk, so a stale
+  // child can never be folded back into the parent that is being repaired.
+  for(const fs::path& path : stale_files)
+    fs::remove(path, ec);
+
+  // ---- 3. Dirty by partial withdrawal ----------------------------------------
+  // A surviving ancestor of anything withdrawn this pass holds folded contributions
+  // that can no longer be subtracted. Ancestors that were themselves removed above are
+  // skipped (nothing to rebuild), and a chain stops as soon as it meets an ancestor
+  // already queued — everything above that is queued too.
+  std::set<gggs::GridIndex> dirty;
+  auto markChainDirty = [&](const gggs::GridIndex& index)
+  {
+    for(gggs::GridIndex a = gggs::parent(index); a.valid(); a = gggs::parent(a))
+    {
+      if(!live.count(a))
+        continue;
+      if(!dirty.insert(a).second)
+        break;
+    }
+  };
+  for(const gggs::GridIndex& index : pruned_fine)
+    markChainDirty(index);
+  for(const gggs::GridIndex& index : gone)
+    markChainDirty(index);
+
+  // Only rebuild overviews that actually exist (resident or on disk) — the pyramid is
+  // built by folding, never by this repair path, so fabricating a tile here would both
+  // invent coverage and do unbounded work. Deepest level first, so a parent's rebuild
+  // sees its children already repaired.
+  std::vector<gggs::GridIndex> targets;
+  for(const gggs::GridIndex& index : dirty)
+    if(overview_tiles_.count(index) ||
+       fs::exists(overviewTilePath(cache_dir_, index), ec))
+      targets.push_back(index);
+  std::sort(targets.begin(), targets.end(),
+            [](const gggs::GridIndex& a, const gggs::GridIndex& b)
+            { return a.level() > b.level(); });
+
+  std::map<gggs::GridIndex, SonarLiveTile> staged;
+  const std::size_t stale_count = gone.size();
+  for(const gggs::GridIndex& index : targets)
+  {
+    std::optional<SonarLiveTile> rebuilt = rebuiltOverview(index, staged, gone);
+    if(rebuilt)
+      staged.emplace(index, std::move(*rebuilt));
+    else
+      gone.insert(index);   // no surviving child: an honest gap beats a stale tile
+  }
+
+  // ---- 4. Apply --------------------------------------------------------------
+  // [camp#134] A removed Entry owns a QOpenGLTexture whose dtor frees GPU resources
+  // ONLY under a current GL context; erasing it without one leaks the texture. Same
+  // hasContext()/makeCurrent()/doneCurrent() discipline as the fine prune above and as
+  // the destructor's teardown.
+  const bool gl_current = !gone.empty() && renderer_.hasContext() && renderer_.makeCurrent();
+  for(const gggs::GridIndex& index : gone)
+  {
+    auto it = overview_tiles_.find(index);
+    if(it != overview_tiles_.end())
+    {
+      it->second.texture.reset();
+      overview_tiles_.erase(it);
+    }
+    cancelPendingWrite(index);
+  }
+  if(gl_current)
+    renderer_.doneCurrent();
+  // Every removed tile's disk copy. The stale-by-absence files were already deleted
+  // above (before the rebuild read children off disk, so a stale child could not be
+  // folded back in) — repeating them here is a harmless no-op and keeps this the single
+  // place that guarantees "in `gone` => no file left behind", which is what the
+  // unrebuildable tiles need.
+  for(const gggs::GridIndex& index : gone)
+    if(!staged.count(index))
+      fs::remove(overviewTilePath(cache_dir_, index), ec);
+
+  for(auto& item : staged)
+  {
+    auto it = overview_tiles_.find(item.first);
+    if(it == overview_tiles_.end())
+      it = overview_tiles_
+             .emplace(item.first, Entry{std::move(item.second), nullptr, true, 0})
+             .first;
+    else
+    {
+      // Mutate the Entry IN PLACE. Replacing it would destroy the old
+      // QOpenGLTexture here, outside any GL context (this runs after doneCurrent());
+      // keeping the texture object and marking it dirty lets textureFor() re-upload it
+      // under the renderer's context at draw time, which is where every other
+      // re-upload happens.
+      it->second.tile = std::move(item.second);
+      it->second.texture_dirty = true;
+    }
+    // Persist the repair, or warm-load would bring the stale content straight back.
+    scheduleWriteThrough(it->second.tile, kOverviewSubdir);
+  }
+
+  const bool changed = !gone.empty() || !staged.empty();
+  if(changed)
+    qInfo().noquote() << "[live coverage" << QString::fromStdString(base_namespace_)
+                      << "] pyramid reconcile: removed" << qulonglong(stale_count)
+                      << "overview tiles with no live descendant and"
+                      << qulonglong(gone.size() - stale_count)
+                      << "with no rebuildable children; rebuilt"
+                      << qulonglong(staged.size()) << "that lost a descendant";
+  return changed;
+}
+
+std::optional<SonarLiveTile> SonarLiveCacheLayer::rebuiltOverview(
+  const gggs::GridIndex& index,
+  const std::map<gggs::GridIndex, SonarLiveTile>& staged,
+  const std::set<gggs::GridIndex>& gone) const
+{
+  // [field 2026-08-27] Rebuild ONE overview tile from scratch out of its surviving
+  // children. foldChild() only ever folds data IN — there is no un-fold — so a tile
+  // that lost a descendant cannot have that contribution subtracted; starting from an
+  // empty parent and re-folding what is left is the only correct repair.
+  //
+  // This reproduces exactly how the tile was built in the first place: foldIntoParent()
+  // folds the WHOLE parent tile into the grandparent, so every pyramid level above the
+  // fine tiles is by construction "the fold of my children". Cells no surviving child
+  // covers stay NoData and are discarded by the renderer.
+  //
+  // std::nullopt means "no child survives" — the caller then removes the tile. A
+  // zoomed-out gap is honest; a knowingly-stale tile is not.
+  if(!level_)
+    return std::nullopt;   // fine level unknown: cannot tell a fine child from a coarse one
+  std::optional<SonarLiveTile> parent;
+  for(const gggs::GridIndex& kid : gggs::children(index))
+  {
+    const std::optional<SonarLiveTile> child = overviewRebuildChild(kid, staged, gone);
+    if(!child)
+      continue;
+    if(!parent)
+      parent.emplace(index, child->width(), child->height());   // foldChild needs same size
+    parent->foldChild(*child);
+  }
+  return parent;
+}
+
+std::optional<SonarLiveTile> SonarLiveCacheLayer::overviewRebuildChild(
+  const gggs::GridIndex& child,
+  const std::map<gggs::GridIndex, SonarLiveTile>& staged,
+  const std::set<gggs::GridIndex>& gone) const
+{
+  // [field 2026-08-27] Freshest copy of one rebuild input, or nullopt when it is gone.
+  // Order: a child already repaired in this same pass (targets run deepest-first) beats
+  // the resident copy, which beats the disk copy. A child this pass withdrew
+  // contributes nothing — that omission IS the repair.
+  if(gone.count(child))
+    return std::nullopt;
+  const auto staged_it = staged.find(child);
+  if(staged_it != staged.end())
+    return staged_it->second;
+
+  std::error_code ec;
+  const bool child_is_fine = (child.level() == *level_);
+  if(child.level() > *level_)
+    return std::nullopt;   // below the finest level this source publishes: no such tile
+  const std::map<gggs::GridIndex, Entry>& pool = child_is_fine ? tiles_ : overview_tiles_;
+  const auto resident = pool.find(child);
+  if(resident != pool.end())
+    return resident->second.tile;
+  // Not resident: the disk cache is the durable backing for BOTH pools (ADR-0010 D2),
+  // so an evicted child is still a valid input. exists() first so a missing file is not
+  // a GDAL open failure on the log.
+  const std::filesystem::path path = child_is_fine ? fineTilePath(cache_dir_, child)
+                                                   : overviewTilePath(cache_dir_, child);
+  if(!std::filesystem::exists(path, ec))
+    return std::nullopt;
+  return SonarLiveTile::loadFromGeoTiff(path.string(), gggs::Level(child.level()));
+}
+
+const SonarLiveTile* SonarLiveCacheLayer::overviewTileForTest(
+  const gggs::GridIndex& index) const
+{
+  const auto it = overview_tiles_.find(index);
+  return it == overview_tiles_.end() ? nullptr : &it->second.tile;
 }
 
 void SonarLiveCacheLayer::evictIfOverBudget()

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
@@ -46,6 +46,13 @@ namespace live_coverage
 /// republished by `udp_bridge`, which is volatile, and a transient-local
 /// subscriber never matches it. Nothing pinned that, which is exactly why the
 /// mismatch went unnoticed. See the definition for the full rationale.
+///
+/// NOT the intended durability, and NOT settled: revert to TRANSIENT_LOCAL once
+/// the boat's bridge config sets `durability: transient_local` on the catalog
+/// topic. udp_bridge already supports it; the config never opted in. Tracked
+/// with the coupled revert in marine_web_view as
+/// rolker/unh_echoboats_project11#484. The definition explains why nothing will
+/// prompt this revert on its own.
 rclcpp::QoS catalogSubscriptionQos();
 
 /// [camp#121] Live coverage cache layer for ONE boat-side source namespace.

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
@@ -14,6 +14,8 @@
 #include "marine_interfaces/msg/tile_catalog.hpp"
 #include "marine_interfaces/msg/tile_request.hpp"
 
+#include <rclcpp/qos.hpp>
+
 #include <QFutureWatcher>
 #include <QImage>
 #include <QPointF>
@@ -36,6 +38,16 @@ namespace ros
 namespace live_coverage
 {
 
+/// QoS used for the `<base>/coverage_catalog` subscription: RELIABLE, depth 1,
+/// and — [field 2026-08-27] — **VOLATILE**.
+///
+/// Exposed (rather than inlined at the subscribe site) so the durability can be
+/// pinned by a regression test: the operator-side subscriber receives the catalog
+/// republished by `udp_bridge`, which is volatile, and a transient-local
+/// subscriber never matches it. Nothing pinned that, which is exactly why the
+/// mismatch went unnoticed. See the definition for the full rationale.
+rclcpp::QoS catalogSubscriptionQos();
+
 /// [camp#121] Live coverage cache layer for ONE boat-side source namespace.
 ///
 /// Renders dequantized in-memory `SonarLiveTile`s through a GL pipeline
@@ -43,7 +55,7 @@ namespace live_coverage
 /// anti-entropy convergence with a `TileCatalogReconciler`. See ADR-0006.
 ///
 /// **Activation model (ADR-0006 D5).** The layer is spawned by discovery in a
-/// *discovered-but-inactive* state: it may subscribe to the cheap, transient-local
+/// *discovered-but-inactive* state: it may subscribe to the cheap, low-rate
 /// `coverage_catalog` to advertise availability, but it does NOT subscribe to the
 /// best-effort `coverage_tiles` stream and does NOT publish `TileRequest` until the
 /// operator enables it (context-menu "Enable live coverage"). Enabling warm-loads
@@ -280,13 +292,15 @@ private:
   // Needed to recover a GridIndex from a cached GeoTIFF on warm-load.
   std::optional<std::uint8_t> level_;
 
-  // [camp#169] Last catalog seen, buffered even while disabled. The catalog
-  // subscription is transient-local depth-1: if the single latched sample is
-  // delivered while enabled_ is false it would otherwise be discarded, and —
-  // the boat's catalog being stable — never re-delivered, so requests would
-  // never resume until a restart (the 2026-07-23 field incident's timing
-  // race). enableLiveCoverage() replays this buffer through handleCatalog()
-  // so reconcile/request fire on every enable.
+  // [camp#169] Last catalog seen, buffered even while disabled. The catalog is
+  // published only on change and the boat's catalog is stable, so a sample
+  // arriving while enabled_ is false would otherwise be discarded and never
+  // re-delivered — requests would not resume until a restart (the 2026-07-23
+  // field incident's timing race). enableLiveCoverage() replays this buffer
+  // through handleCatalog() so reconcile/request fire on every enable.
+  // [field 2026-08-27] With the subscription now volatile (see catalogSubscriptionQos())
+  // there is no latched sample either, which makes this buffer the only bridge
+  // from a catalog seen while disabled to a reconcile on enable.
   std::optional<marine_interfaces::msg::TileCatalog> last_catalog_;
 
   // [camp#134] The shared GL raster renderer (its own offscreen context + the

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
@@ -118,17 +118,45 @@ public:
   /// write-through instead of pinning the in-memory repair.
   const SonarLiveTile* overviewTileForTest(const gggs::GridIndex& index) const;
 
+  /// [field 2026-08-27 / ADR-0010 D5] One resolved contribution to the draw list.
+  ///
+  /// `footprint` is the GGGS index whose geographic extent is painted; `source` is
+  /// the index of the RESIDENT tile whose texture supplies the pixels. For a
+  /// resident fine tile the two are the same index and the whole texture is used.
+  /// For a **coarse placeholder** — a fine tile that is known to exist but is not
+  /// resident — `source` is the finest resident ancestor overview and the sampled
+  /// region is the sub-rect `[u0,v0]-[u1,v1]` of it that the footprint occupies, so
+  /// the coarse data is CLIPPED to that one fine tile's footprint and never painted
+  /// across the overview's own (vastly larger) extent.
+  struct DrawItem
+  {
+    gggs::GridIndex footprint;   ///< extent painted (a fine index)
+    gggs::GridIndex source;      ///< resident tile supplying the texture
+    bool placeholder = false;    ///< source is an overview sampled through a sub-rect
+    float u0 = 0.0f;             ///< west edge of the sampled sub-rect
+    float v0 = 0.0f;             ///< north edge (texture row 0 = north)
+    float u1 = 1.0f;             ///< east edge
+    float v1 = 1.0f;             ///< south edge
+  };
+
+  /// [field 2026-08-27 / ADR-0010 D5] Resolve what this layer draws for
+  /// @p clip_scene (Web-Mercator; a null rect means "no clip", as in items()):
+  /// the coarse placeholders first, then every resident fine tile. GL-free and
+  /// side-effect-free — itemsIntersecting() turns this list into RasterFieldItems
+  /// (uploading textures), and the draw-selection tests drive it directly.
+  std::vector<DrawItem> planDraw(const QRectF& clip_scene) const;
+
   /// [camp#121] Render the in-memory tiles into an offscreen image of @p size
   /// spanning the layer extent. Null image if there is no data / GL is
   /// unavailable. Exposed for a headless render check (skips with no GL).
   QImage renderImage(const QSize& size);
 
-  /// [camp#103 / ADR-0011] Clip-aware overload: render only the tiles whose
-  /// scene extent intersects @p clip_bounds (a sub-rect of sceneBounds(),
-  /// Web-Mercator metres) into an image of @p size spanning exactly
-  /// @p clip_bounds. Filters BOTH pools while preserving the overviews-first
-  /// draw order (the ADR-0010 LOD fallback). paint() uses it with the
-  /// viewport-derived clip; public (mirroring renderImage(size)) for tests.
+  /// [camp#103 / ADR-0011] Clip-aware overload: render only what intersects
+  /// @p clip_bounds (a sub-rect of sceneBounds(), Web-Mercator metres) into an
+  /// image of @p size spanning exactly @p clip_bounds — the resident fine tiles
+  /// plus the coarse placeholders planDraw() resolves for the not-yet-loaded ones
+  /// (ADR-0010 D5). paint() uses it with the viewport-derived clip; public
+  /// (mirroring renderImage(size)) for tests.
   QImage renderImage(const QSize& size, const QRectF& clip_bounds);
 
   /// The layer's Web-Mercator extent (union of tile extents). Exposed for tests.
@@ -298,11 +326,27 @@ private:
   QOpenGLTexture* textureFor(Entry& entry);
 
   /// [camp#103] items() body with an optional scene-space clip: a non-null
-  /// @p clip_scene keeps only tiles whose Web-Mercator extent intersects it,
-  /// tested BEFORE the lazy texture upload. Filters both pools, preserving the
-  /// overviews-first draw order (ADR-0010 LOD fallback). items() (the
-  /// RasterFieldSource interface) delegates with a null rect.
+  /// @p clip_scene keeps only the tiles/footprints whose Web-Mercator extent
+  /// intersects it, tested BEFORE the lazy texture upload, so an offscreen tile is
+  /// neither uploaded nor drawn. items() (the RasterFieldSource interface)
+  /// delegates with a null rect. The selection itself is planDraw()'s.
   QList<raster::RasterFieldItem> itemsIntersecting(const QRectF& clip_scene);
+
+  /// [field 2026-08-27 / ADR-0010 D5] The fine indices that are KNOWN TO EXIST but
+  /// are not resident — the set a coarse placeholder may be drawn for, and nothing
+  /// else. Two authorities, unioned: the boat's catalog (`catalogued_fine_`, which
+  /// is authoritative for what exists) and `evicted_fine_indices_` (locally known
+  /// to be on disk — the only authority when no catalog has arrived, e.g. a warm
+  /// start with the link down). Resident indices are excluded: they draw
+  /// themselves at full resolution.
+  std::set<gggs::GridIndex> pendingFineIndices() const;
+
+  /// [field 2026-08-27] The finest resident overview tile that CONTAINS @p index,
+  /// or nullptr when the pyramid has nothing over it (an honest gap — we draw
+  /// nothing rather than inventing coverage). Walks `gggs::parent()` up from
+  /// @p index, so it stops at the first hit: the best available resolution.
+  const Entry* finestResidentAncestor(const gggs::GridIndex& index,
+                                      gggs::GridIndex* source) const;
 
   static constexpr int kMaxImageEdge = 4096;
 
@@ -352,8 +396,14 @@ private:
   // [camp#160] Coarse overview (pyramid) tiles keyed by their own GGGS index at a
   // level below tiles_'s. Built by folding evicted fine tiles into their parents,
   // kept resident (all but the numerous near-fine levels — see evictIfOverBudget
-  // phase 2), and rendered *under* the fine tiles so an evicted area degrades to a
-  // coarser resolution instead of going blank. These are a LOCAL derived product:
+  // phase 2), and sampled as the PLACEHOLDER source for a fine tile that is known
+  // to exist but is not resident, so an evicted area degrades to a coarser
+  // resolution instead of going blank.
+  // [field 2026-08-27] An overview tile is NEVER drawn over its own extent — only
+  // ever through the footprint of one such fine tile (ADR-0010 D5 / planDraw). Its
+  // own extent covers water nobody surveyed, and painting the mean of everything
+  // folded beneath a coarse cell across all of it hides the chart underneath.
+  // These are a LOCAL derived product:
   // they are NEVER entered into `reconciler_` (ADR-0010 D4 — they are absent from the
   // boat's catalog, so reconciling them directly would prune every one of them on the
   // first catalog).
@@ -369,6 +419,16 @@ private:
   // when it is reloaded (onReloadFinished, whether the load succeeded or not),
   // re-received live (handleTile), or pruned by the catalog (handleCatalog).
   std::set<gggs::GridIndex> evicted_fine_indices_;
+
+  // [field 2026-08-27 / ADR-0010 D5] The fine indices of the last catalog — the
+  // boat's authoritative statement of which tiles EXIST. Maintained from every
+  // catalog (including one that arrives while disabled, which handleCatalog also
+  // buffers for replay), it is the set a coarse placeholder is allowed to be drawn
+  // for: coarse data is a stand-in for a specific fine tile that has not loaded,
+  // never a wash over the overview's own extent. Empty until the first catalog —
+  // pendingFineIndices() then falls back to evicted_fine_indices_ alone, which is
+  // what a warm start with no link has.
+  std::set<gggs::GridIndex> catalogued_fine_;
 
   // [camp#172] Async reload worker (loads evicted fine GeoTIFFs off the GUI thread) and
   // the moved-since-last-kick guard, mirroring GggsTileLayer's demand-driven loader.

--- a/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
+++ b/src/camp_map/ros/live_coverage/sonar_live_cache_layer.h
@@ -111,6 +111,12 @@ public:
   /// [camp#160] Number of indices the reconciler holds — used by tests to assert
   /// overview tiles never enter the anti-entropy set (ADR-0010 D4).
   std::size_t reconcilerHeldCount() const { return reconciler_.size(); }
+  /// [field 2026-08-27] Test seam: the resident overview tile at @p index, or nullptr
+  /// when it is not resident. The pyramid prune-on-absence test needs the CONTENT of a
+  /// rebuilt overview (did the withdrawn descendant's contribution actually leave?),
+  /// which a count cannot express; reading it back off disk would race the async
+  /// write-through instead of pinning the in-memory repair.
+  const SonarLiveTile* overviewTileForTest(const gggs::GridIndex& index) const;
 
   /// [camp#121] Render the in-memory tiles into an offscreen image of @p size
   /// spanning the layer extent. Null image if there is no data / GL is
@@ -218,6 +224,11 @@ private:
   void startWriteThrough(const gggs::GridIndex& index);
   void onWriteThroughFinished(const gggs::GridIndex& index,
                               QFutureWatcher<void>* watcher);
+  // [field 2026-08-27] Drop a deleted tile's queued write-through so a coalesced
+  // relaunch can't re-create the file a prune just removed. An in-flight write is left
+  // to finish (its WriteState must survive, or a later fold would launch a second
+  // worker racing it on the shared `<stem>.tif.tmp` path) — see the definition.
+  void cancelPendingWrite(const gggs::GridIndex& index);
 
   // [camp#160] Bounded eviction + overview pyramid (view-based LOD).
   // accountedBytes(): resident fine-tile footprint (CPU band data + any uploaded
@@ -233,6 +244,29 @@ private:
   void evictIfOverBudget();
   void foldIntoParent(const SonarLiveTile& fine);
   std::optional<QPointF> currentViewCentre() const;
+
+  // [field 2026-08-27 / ADR-0010 D7] Propagate anti-entropy prune-on-absence into the
+  // derived overview pyramid. The catalog is authoritative over the fine tiles, and the
+  // pyramid is a function of them, so an overview SHOULD exist exactly when it is an
+  // ancestor of a live fine index. reconcilePyramid() removes the overviews with no
+  // live descendant (memory + GPU texture + disk, including the `overviews/` files of
+  // non-resident ones) and rebuilds those that merely lost one — foldChild() has no
+  // inverse, so a withdrawn contribution can never be subtracted in place.
+  // rebuiltOverview() re-folds one tile from its surviving children (nullopt = nothing
+  // survives, so the caller removes it: an honest gap beats stale coverage);
+  // overviewRebuildChild() resolves one input, preferring a child repaired earlier in
+  // the same pass, then the resident copy, then the disk copy. Returns true when the
+  // pyramid changed. GUI thread only (ADR-0006 D4).
+  bool reconcilePyramid(const marine_tiled_raster_store::TileCatalog& catalog,
+                        const std::vector<gggs::GridIndex>& pruned_fine);
+  std::optional<SonarLiveTile> rebuiltOverview(
+    const gggs::GridIndex& index,
+    const std::map<gggs::GridIndex, SonarLiveTile>& staged,
+    const std::set<gggs::GridIndex>& gone) const;
+  std::optional<SonarLiveTile> overviewRebuildChild(
+    const gggs::GridIndex& child,
+    const std::map<gggs::GridIndex, SonarLiveTile>& staged,
+    const std::set<gggs::GridIndex>& gone) const;
 
   // [camp#172] On-demand reload of evicted fine tiles (the ADR-0013 §"camp#172 hook").
   // hasUnloadedVisibleTiles(): does the viewport expose an evicted fine index whose
@@ -317,10 +351,16 @@ private:
 
   // [camp#160] Coarse overview (pyramid) tiles keyed by their own GGGS index at a
   // level below tiles_'s. Built by folding evicted fine tiles into their parents,
-  // kept resident (never evicted — a handful of tiles), and rendered *under* the
-  // fine tiles so an evicted area degrades to a coarser resolution instead of
-  // going blank. These are a LOCAL derived product: they are NEVER entered into
-  // `reconciler_`, so anti-entropy prune-on-absence can't delete them.
+  // kept resident (all but the numerous near-fine levels — see evictIfOverBudget
+  // phase 2), and rendered *under* the fine tiles so an evicted area degrades to a
+  // coarser resolution instead of going blank. These are a LOCAL derived product:
+  // they are NEVER entered into `reconciler_` (ADR-0010 D4 — they are absent from the
+  // boat's catalog, so reconciling them directly would prune every one of them on the
+  // first catalog).
+  // [field 2026-08-27] That is a statement about reconciler membership only. It is NOT
+  // an exemption from prune-on-absence, though the code read as if it were: see
+  // reconcilePyramid(), which converges this map (and the `overviews/` sub-dir) to the
+  // ancestors of the live fine set on every catalog.
   std::map<gggs::GridIndex, Entry> overview_tiles_;
 
   // [camp#172] Fine indices that were evicted (folded to overview + dropped from

--- a/test/test_raster_gl_renderer.cpp
+++ b/test/test_raster_gl_renderer.cpp
@@ -419,6 +419,74 @@ TEST(RasterGlRendererTest, NonFiniteAnchorIsDroppedAtTheSeam)
   EXPECT_FLOAT_EQ(*renderer.shorelineAnchor(), -28.0f);
 }
 
+// [field 2026-08-27 / ADR-0010 D5] The texture sub-rect. An item may sample a window
+// of its texture instead of the whole of it — how the live-coverage coarse placeholder
+// paints ONE missing fine tile's footprint out of an overview that spans many. Two
+// halves are pinned: the default window is still the whole texture (every pre-existing
+// caller must be untouched by the new field), and a narrowed window samples exactly the
+// quadrant asked for, with v running north->south like the vertex generation does.
+TEST(RasterGlRendererTest, TextureWindowSamplesTheRequestedSubRect)
+{
+  if(!offscreenGLAvailable())
+    GTEST_SKIP() << "no offscreen GL context available";
+
+  RasterGlRenderer renderer;
+  ASSERT_TRUE(renderer.makeCurrent());
+  renderer.setColormap("grayscale");
+
+  // 4x4, uniform within each quadrant and distinct between them (row 0 = north).
+  const int n = 4;
+  const float nw = 10.0f, ne = 7.0f, sw = 4.0f, se = 1.0f;
+  std::vector<float> data(n * n, 0.0f);
+  for(int row = 0; row < n; ++row)
+    for(int col = 0; col < n; ++col)
+      data[row * n + col] = (row < 2) ? (col < 2 ? nw : ne) : (col < 2 ? sw : se);
+  auto tex = makeScalarTexture(n, n, data);
+
+  const RasterFieldItem whole = scalarItem(tex.get(), n, /*has_nodata=*/false, 0.0f);
+  const QRectF bounds(0, 0, n, n);
+  const QSize size(n, n);
+
+  // Default window: all four quadrants, each in its own corner — unchanged behaviour.
+  const QImage full = renderer.renderToImage({whole}, bounds, 0.0f, 10.0f, size);
+  ASSERT_FALSE(full.isNull());
+  const int nw_red = full.pixelColor(0, 0).red();
+  const int ne_red = full.pixelColor(3, 0).red();
+  const int sw_red = full.pixelColor(0, 3).red();
+  const int se_red = full.pixelColor(3, 3).red();
+  EXPECT_GT(nw_red, ne_red);
+  EXPECT_GT(ne_red, sw_red);
+  EXPECT_GT(sw_red, se_red);
+
+  // Each quadrant in turn, stretched over the whole quad: every output pixel must
+  // carry that quadrant's value and nothing from its neighbours. The south-west and
+  // north-east cases are the ones that catch a flipped v.
+  struct Case { const char* name; float u0, v0, u1, v1; int expected; };
+  const Case cases[] = {
+    {"north-west", 0.0f, 0.0f, 0.5f, 0.5f, nw_red},
+    {"north-east", 0.5f, 0.0f, 1.0f, 0.5f, ne_red},
+    {"south-west", 0.0f, 0.5f, 0.5f, 1.0f, sw_red},
+    {"south-east", 0.5f, 0.5f, 1.0f, 1.0f, se_red},
+  };
+  for(const Case& c : cases)
+  {
+    RasterFieldItem item = whole;
+    item.u0 = c.u0;
+    item.v0 = c.v0;
+    item.u1 = c.u1;
+    item.v1 = c.v1;
+    const QImage img = renderer.renderToImage({item}, bounds, 0.0f, 10.0f, size);
+    ASSERT_FALSE(img.isNull()) << c.name;
+    for(int y = 0; y < n; ++y)
+      for(int x = 0; x < n; ++x)
+        EXPECT_EQ(img.pixelColor(x, y).red(), c.expected)
+          << c.name << " window leaked a neighbouring quadrant at " << x << "," << y;
+  }
+
+  tex.reset();
+  renderer.doneCurrent();
+}
+
 int main(int argc, char** argv)
 {
   qputenv("QT_QPA_PLATFORM", "offscreen");

--- a/test/test_sonar_live_catalog_qos.cpp
+++ b/test/test_sonar_live_catalog_qos.cpp
@@ -1,0 +1,44 @@
+// [field 2026-08-27] Headless regression test: the `coverage_catalog` subscription QoS
+// must be RELIABLE / depth 1 / **VOLATILE**.
+//
+// camp runs on the operator side and receives the catalog as republished by
+// `udp_bridge`, which publishes VOLATILE. The subscription had been written to
+// match the boat-side producer (transient-local) instead, which is
+// QoS-incompatible with a volatile publisher: the subscription never matched,
+// handleCatalog() never fired, and the anti-entropy reconcile (ADR-0006 D4)
+// never pruned — stale coverage stayed on screen for the whole session.
+// Measured live on pandy during the BizzyBoat deployment: publisher
+// /operator/udp_bridge RELIABLE/VOLATILE vs subscriber /operator/camp
+// RELIABLE/TRANSIENT_LOCAL.
+//
+// Nothing pinned this durability, which is precisely why the mismatch was
+// invisible. This test pins it. No ROS graph, no Qt objects, no GL — it asserts
+// on the QoS profile the subscribe site uses.
+
+#include <gtest/gtest.h>
+
+#include <rclcpp/qos.hpp>
+
+#include "ros/live_coverage/sonar_live_cache_layer.h"
+
+using camp::ros::live_coverage::catalogSubscriptionQos;
+
+TEST(SonarLiveCatalogQos, DurabilityIsVolatileToMatchUdpBridge)
+{
+  const rmw_qos_profile_t profile = catalogSubscriptionQos().get_rmw_qos_profile();
+  EXPECT_EQ(profile.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}
+
+TEST(SonarLiveCatalogQos, ReliableDepthOne)
+{
+  const rmw_qos_profile_t profile = catalogSubscriptionQos().get_rmw_qos_profile();
+  EXPECT_EQ(profile.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+  EXPECT_EQ(profile.history, RMW_QOS_POLICY_HISTORY_KEEP_LAST);
+  EXPECT_EQ(profile.depth, 1u);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_sonar_live_overview_prune.cpp
+++ b/test/test_sonar_live_overview_prune.cpp
@@ -1,0 +1,487 @@
+// [field 2026-08-27] Headless regression test: anti-entropy prune-on-absence must
+// propagate into the DERIVED overview pyramid (ADR-0010 D7).
+//
+// The catalog reconcile pruned only `tiles_` (memory + GPU + the fine `.tif`). The
+// overview pyramid built by foldIntoParent() was exempt, so a retracted region kept its
+// coarse coverage forever: the `overviews/` files survived every prune and warm-load
+// brought them straight back on the next restart. Measured on pandy during the
+// BizzyBoat deployment after a boat-side store reset — the fine cache pruned correctly
+// (107M -> 44M, every survivor newer than the restart) while 41M of `overviews/`
+// survived and the operator still saw the pre-reset coverage.
+//
+// Compounding it, the fold is purely accumulative: foldChild() only ever folds data IN
+// and has no inverse, so an overview that lost SOME of its descendants cannot have the
+// withdrawn contribution subtracted in place — it has to be rebuilt from what is left.
+//
+// What is pinned here:
+//   * StaleOverviewsRemoved      an overview with no catalogued descendant leaves both
+//                                memory and disk;
+//   * SurvivingAncestorsKept     an overview that still has a catalogued descendant is
+//                                NOT removed — the over-deletion guard. Every pruned
+//                                tile's ancestor chain reaches level 0, so a naive
+//                                invalidate-the-chain would destroy the whole pyramid
+//                                on any ordinary retraction;
+//   * SharedAncestorRebuilt      an overview that lost only SOME descendants is rebuilt
+//                                from the survivors, so the withdrawn tile's values are
+//                                really gone from it (partial withdrawal);
+//   * RoutineCatalogLeavesPyramidAlone  a catalog that retracts nothing touches nothing;
+//   * UnstampedCatalogDoesNotSweep      generation_time 0 disables prune-on-absence in
+//                                the reconciler (ADR-0008 D4b), so it must disable the
+//                                pyramid sweep too — otherwise an un-stamped catalog
+//                                would delete the pyramid while every fine tile stayed.
+//
+// Offscreen QApplication + Map harness as test_sonar_live_eviction / _resume: GL-free
+// (renderImage() is never called, so no texture is ever uploaded) and ROS-free (null
+// Node -> no subscription; handleCatalog is invoked by name exactly as the ROS
+// callback's GUI-thread marshal does).
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QDir>
+#include <QEvent>
+#include <QFileInfo>
+#include <QMetaObject>
+#include <QSettings>
+#include <QTemporaryDir>
+#include <QUrl>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_interfaces/msg/sonar_visualization_tile.hpp"
+#include "marine_interfaces/msg/tile_catalog.hpp"
+#include "marine_interfaces/msg/visualization_band.hpp"
+
+#include "map/map.h"
+#include "map/layer_list.h"
+#include "ros/live_coverage/sonar_live_cache_layer.h"
+#include "ros/live_coverage/sonar_live_tile.h"
+
+namespace mi = marine_interfaces::msg;
+using camp::map::Map;
+using camp::ros::live_coverage::SonarLiveBand;
+using camp::ros::live_coverage::SonarLiveCacheLayer;
+using camp::ros::live_coverage::SonarLiveTile;
+using camp::ros::live_coverage::tileIndexFromGridIndex;
+
+namespace
+{
+
+constexpr int kLevel = 10;
+constexpr int kEdge = 8;
+constexpr std::int16_t kKeepBase = 300;   // 3.00 m — the tile the catalog keeps
+constexpr std::int16_t kDropBase = 500;   // 5.00 m — the tile the catalog withdraws
+
+QString sanitizeNamespace(const QString& ns)
+{
+  return QString::fromLatin1(QUrl::toPercentEncoding(ns));
+}
+
+// A uniform full-tile INT16 "depth" patch (value = base * 0.01) for @p grid.
+mi::SonarVisualizationTile makeUniformDepth(const gggs::GridIndex& grid, std::int16_t base)
+{
+  mi::SonarVisualizationTile msg;
+  msg.header.stamp.sec = 100;
+  msg.header.frame_id = "gggs";
+  msg.index = tileIndexFromGridIndex(grid);
+  msg.width = kEdge;
+  msg.height = kEdge;
+  msg.window_col = 0;
+  msg.window_row = 0;
+  msg.window_width = kEdge;
+  msg.window_height = kEdge;
+
+  mi::VisualizationBand band;
+  band.name = "depth";
+  band.dtype = mi::VisualizationBand::INT16;
+  band.scale = 0.01;
+  band.offset = 0.0;
+  band.nodata = -32768.0;
+  for(int i = 0; i < kEdge * kEdge; ++i)
+  {
+    band.data.push_back(static_cast<std::uint8_t>(base & 0xff));
+    band.data.push_back(static_cast<std::uint8_t>((base >> 8) & 0xff));
+  }
+  msg.bands.push_back(band);
+  return msg;
+}
+
+QString stemOf(const gggs::GridIndex& index)
+{
+  return QString("%1_%2_%3")
+    .arg(static_cast<int>(index.level()))
+    .arg(index.row())
+    .arg(index.column());
+}
+
+// Every strict ancestor of @p index, finest first, up to level 0.
+std::vector<gggs::GridIndex> ancestorChain(const gggs::GridIndex& index)
+{
+  std::vector<gggs::GridIndex> chain;
+  for(gggs::GridIndex a = gggs::parent(index); a.valid(); a = gggs::parent(a))
+    chain.push_back(a);
+  return chain;
+}
+
+// The layer's cache layout for one source namespace.
+struct CachePaths
+{
+  QString fine;
+  QString overviews;
+
+  QString finePath(const gggs::GridIndex& index) const
+  {
+    return QDir(fine).filePath(stemOf(index) + ".tif");
+  }
+  QString overviewPath(const gggs::GridIndex& index) const
+  {
+    return QDir(overviews).filePath(stemOf(index) + ".tif");
+  }
+};
+
+// Seed the on-disk cache the way a live session would have left it: each fine tile at
+// the cache-dir root, plus the full overview chain each one folds into, mirroring
+// foldIntoParent() (fold the fine tile into its parent, then the WHOLE parent into the
+// grandparent, up to level 0). Returns the layout so a test can assert on the files.
+CachePaths seedCache(const QString& cache_root, const QString& ns,
+                     const std::vector<std::pair<gggs::GridIndex, std::int16_t>>& fine_tiles)
+{
+  CachePaths paths;
+  paths.fine = QDir(cache_root).filePath(sanitizeNamespace(ns));
+  paths.overviews = QDir(paths.fine).filePath("overviews");
+  EXPECT_TRUE(QDir().mkpath(paths.fine));
+  EXPECT_TRUE(QDir().mkpath(paths.overviews));
+
+  std::map<gggs::GridIndex, SonarLiveTile> overviews;
+  for(const auto& [grid, base] : fine_tiles)
+  {
+    SonarLiveTile tile(grid, kEdge, kEdge);
+    tile.applyPatch(makeUniformDepth(grid, base));
+    EXPECT_TRUE(tile.writeToGeoTiff(paths.finePath(grid).toStdString()));
+
+    // Walk the chain, folding the accumulated tile into each successive parent.
+    const SonarLiveTile* child = &tile;
+    for(const gggs::GridIndex& ancestor : ancestorChain(grid))
+    {
+      auto it = overviews.find(ancestor);
+      if(it == overviews.end())
+        it = overviews.emplace(ancestor, SonarLiveTile(ancestor, kEdge, kEdge)).first;
+      it->second.foldChild(*child);
+      child = &it->second;
+    }
+  }
+  for(const auto& [index, tile] : overviews)
+    EXPECT_TRUE(tile.writeToGeoTiff(paths.overviewPath(index).toStdString()));
+  return paths;
+}
+
+mi::TileCatalog catalogOf(const std::vector<gggs::GridIndex>& indices, std::int32_t stamp_sec)
+{
+  mi::TileCatalog catalog;
+  catalog.header.stamp.sec = stamp_sec;
+  for(const gggs::GridIndex& index : indices)
+  {
+    mi::TileCatalogEntry entry;
+    entry.index = tileIndexFromGridIndex(index);
+    entry.version.sec = 150;
+    catalog.entries.push_back(entry);
+  }
+  return catalog;
+}
+
+bool deliverCatalog(SonarLiveCacheLayer* layer, const mi::TileCatalog& catalog)
+{
+  return QMetaObject::invokeMethod(layer, "handleCatalog", Qt::DirectConnection,
+                                   Q_ARG(marine_interfaces::msg::TileCatalog, catalog));
+}
+
+// Cells of the tile's "depth" band that carry real data (NaN / NoData never count),
+// and of those, how many hold something OTHER than @p value.
+//
+// The assertions are written as "every finite cell equals the kept tile's value"
+// rather than "no cell equals the withdrawn tile's value" on purpose: the fold takes
+// the MEAN of the child cells landing in a parent cell, so at coarse levels the two
+// fine tiles collapse into the SAME parent cell and the withdrawn 5.00 shows up as a
+// 4.00 mean, not as a 5.00. Any contribution from the withdrawn tile — direct or
+// averaged — moves a cell off 3.00, so this catches both.
+std::size_t finiteCellCount(const SonarLiveTile& tile)
+{
+  const SonarLiveBand* band = tile.band("depth");
+  if(!band)
+    return 0;
+  std::size_t hits = 0;
+  for(float v : band->data)
+    if(std::isfinite(v) && !(band->has_nodata && v == band->nodata))
+      ++hits;
+  return hits;
+}
+
+std::size_t cellsUnequalTo(const SonarLiveTile& tile, float value)
+{
+  const SonarLiveBand* band = tile.band("depth");
+  if(!band)
+    return 0;
+  std::size_t hits = 0;
+  for(float v : band->data)
+    if(std::isfinite(v) && !(band->has_nodata && v == band->nodata) &&
+       std::fabs(v - value) >= 1e-3f)
+      ++hits;
+  return hits;
+}
+
+constexpr float kKeepValue = 0.01f * kKeepBase;
+
+// The shared test fixture data: two well-separated fine tiles, the ancestors unique to
+// each, and the ancestors they share.
+struct Fixture
+{
+  gggs::GridIndex keep;    // stays in the catalog
+  gggs::GridIndex drop;    // withdrawn by the catalog
+  std::vector<gggs::GridIndex> keep_only;    // ancestors of `keep` alone
+  std::vector<gggs::GridIndex> drop_only;    // ancestors of `drop` alone
+  std::vector<gggs::GridIndex> shared;       // ancestors of both, coarsest-common up
+  CachePaths paths;
+};
+
+Fixture makeFixture(const QString& cache_root, const QString& ns)
+{
+  Fixture f;
+  const gggs::Level level(kLevel);
+  // Same longitude, ~0.15 deg apart in latitude: identical grids down to level 5
+  // (0.25 deg spans) and distinct from level 6 (0.125 deg) on down. That gives the
+  // fixture a multi-level SHARED ancestor chain (levels 0-5, the rebuild targets) as
+  // well as exclusive chains for each tile (levels 6-9), all asserted below rather
+  // than assumed.
+  f.keep = level.gridIndex(43.05, -70.55);
+  f.drop = level.gridIndex(43.20, -70.55);
+  EXPECT_TRUE(f.keep.valid());
+  EXPECT_TRUE(f.drop.valid());
+  EXPECT_FALSE(f.keep == f.drop);
+
+  const std::vector<gggs::GridIndex> keep_chain = ancestorChain(f.keep);
+  const std::vector<gggs::GridIndex> drop_chain = ancestorChain(f.drop);
+  for(const gggs::GridIndex& a : keep_chain)
+  {
+    const bool in_drop =
+      std::find(drop_chain.begin(), drop_chain.end(), a) != drop_chain.end();
+    if(in_drop)
+      f.shared.push_back(a);
+    else
+      f.keep_only.push_back(a);
+  }
+  for(const gggs::GridIndex& a : drop_chain)
+    if(std::find(keep_chain.begin(), keep_chain.end(), a) == keep_chain.end())
+      f.drop_only.push_back(a);
+
+  // Fail loudly rather than passing vacuously if the chosen coordinates stop yielding
+  // all three ancestor classes.
+  EXPECT_FALSE(f.keep_only.empty());
+  EXPECT_FALSE(f.drop_only.empty());
+  EXPECT_FALSE(f.shared.empty());
+
+  f.paths = seedCache(cache_root, ns, {{f.keep, kKeepBase}, {f.drop, kDropBase}});
+  return f;
+}
+
+// Configure a generous budget so eviction never interferes, and point the layer at the
+// temp cache.
+void useCache(const QString& cache_root)
+{
+  QSettings().clear();
+  QSettings().setValue("LiveTileCache/cache_dir", cache_root);
+  const std::size_t per_tile = static_cast<std::size_t>(kEdge) * kEdge * sizeof(float);
+  QSettings().setValue("LiveTileCache/max_vram_bytes", qulonglong(1000 * per_tile));
+}
+
+}  // namespace
+
+// An overview tile whose every descendant vanished from the catalog is entirely stale:
+// it must leave memory AND disk. Nothing else in the pyramid may be touched.
+TEST(SonarLiveOverviewPrune, StaleOverviewsRemovedAndSurvivingAncestorsKept)
+{
+  QTemporaryDir cache;
+  ASSERT_TRUE(cache.isValid());
+  useCache(cache.path());
+
+  const QString ns = "/overview_prune_test";
+  const Fixture f = makeFixture(cache.path(), ns);
+
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  auto* layer = new SonarLiveCacheLayer(layers, nullptr, ns);
+
+  layer->enableLiveCoverage();
+  ASSERT_EQ(layer->residentTileCount(), std::size_t(2));
+  ASSERT_EQ(layer->overviewTileCount(),
+            f.keep_only.size() + f.drop_only.size() + f.shared.size());
+
+  // The boat now holds only `keep`. generation_time must be non-zero or the
+  // reconciler's prune gate (ADR-0008 D4b) declines to prune at all.
+  ASSERT_TRUE(deliverCatalog(layer, catalogOf({f.keep}, 200)));
+
+  // The fine tile went, as before this change.
+  EXPECT_EQ(layer->residentTileCount(), std::size_t(1));
+  EXPECT_FALSE(QFileInfo::exists(f.paths.finePath(f.drop)));
+  EXPECT_TRUE(QFileInfo::exists(f.paths.finePath(f.keep)));
+
+  // ...and now so did every overview that existed only for it — this is what used to
+  // survive, in memory and on disk, and come back on every restart via warm-load.
+  for(const gggs::GridIndex& a : f.drop_only)
+  {
+    EXPECT_EQ(layer->overviewTileForTest(a), nullptr) << "resident: " << a;
+    EXPECT_FALSE(QFileInfo::exists(f.paths.overviewPath(a))) << "on disk: " << a;
+  }
+
+  // The over-deletion guard. Every pruned tile's ancestor chain runs all the way to
+  // level 0, so a chain-invalidating fix would have wiped the pyramid here. Ancestors
+  // with a surviving catalogued descendant must all still be present.
+  for(const gggs::GridIndex& a : f.keep_only)
+  {
+    EXPECT_NE(layer->overviewTileForTest(a), nullptr) << "resident: " << a;
+    EXPECT_TRUE(QFileInfo::exists(f.paths.overviewPath(a))) << "on disk: " << a;
+  }
+  for(const gggs::GridIndex& a : f.shared)
+  {
+    EXPECT_NE(layer->overviewTileForTest(a), nullptr) << "resident: " << a;
+    EXPECT_TRUE(QFileInfo::exists(f.paths.overviewPath(a))) << "on disk: " << a;
+  }
+}
+
+// Partial withdrawal: an ancestor shared by a kept and a withdrawn tile survives, but
+// it still holds the withdrawn tile's folded cells. foldChild() has no inverse, so it
+// must be REBUILT from its surviving children rather than kept as-is.
+TEST(SonarLiveOverviewPrune, SharedAncestorRebuiltWithoutTheWithdrawnDescendant)
+{
+  QTemporaryDir cache;
+  ASSERT_TRUE(cache.isValid());
+  useCache(cache.path());
+
+  const QString ns = "/overview_rebuild_test";
+  const Fixture f = makeFixture(cache.path(), ns);
+
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  auto* layer = new SonarLiveCacheLayer(layers, nullptr, ns);
+  layer->enableLiveCoverage();
+
+  // Precondition: every shared ancestor carries the withdrawn tile's contribution —
+  // some finite cell is not the kept tile's value.
+  for(const gggs::GridIndex& a : f.shared)
+  {
+    const SonarLiveTile* tile = layer->overviewTileForTest(a);
+    ASSERT_NE(tile, nullptr) << a;
+    EXPECT_GT(finiteCellCount(*tile), std::size_t(0)) << a;
+    EXPECT_GT(cellsUnequalTo(*tile, kKeepValue), std::size_t(0)) << a;
+  }
+
+  ASSERT_TRUE(deliverCatalog(layer, catalogOf({f.keep}, 200)));
+
+  for(const gggs::GridIndex& a : f.shared)
+  {
+    const SonarLiveTile* tile = layer->overviewTileForTest(a);
+    ASSERT_NE(tile, nullptr) << a;
+    // ...and the surviving descendant's coverage is intact: the repair must not empty
+    // the tile out, which would trade stale coverage for no coverage.
+    EXPECT_GT(finiteCellCount(*tile), std::size_t(0))
+      << "rebuild lost the surviving descendant at " << a;
+    // The withdrawn tile's contribution is gone (directly or as a mean).
+    EXPECT_EQ(cellsUnequalTo(*tile, kKeepValue), std::size_t(0))
+      << "withdrawn contribution still folded into " << a;
+  }
+
+  // The repair is persisted, or warm-load would bring the stale content straight back
+  // on the next restart — the mechanism that kept the pandy pyramid alive.
+  layer->deleteLater();
+  QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+  const gggs::GridIndex apex = f.shared.back();
+  const std::optional<SonarLiveTile> from_disk = SonarLiveTile::loadFromGeoTiff(
+    f.paths.overviewPath(apex).toStdString(), gggs::Level(apex.level()));
+  ASSERT_TRUE(from_disk.has_value());
+  EXPECT_GT(finiteCellCount(*from_disk), std::size_t(0));
+  EXPECT_EQ(cellsUnequalTo(*from_disk, kKeepValue), std::size_t(0));
+}
+
+// Routine churn: a catalog that retracts nothing must leave the pyramid completely
+// alone — no removals, no rebuilds, no lost coverage.
+TEST(SonarLiveOverviewPrune, RoutineCatalogLeavesPyramidAlone)
+{
+  QTemporaryDir cache;
+  ASSERT_TRUE(cache.isValid());
+  useCache(cache.path());
+
+  const QString ns = "/overview_churn_test";
+  const Fixture f = makeFixture(cache.path(), ns);
+
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  auto* layer = new SonarLiveCacheLayer(layers, nullptr, ns);
+  layer->enableLiveCoverage();
+  const std::size_t before = layer->overviewTileCount();
+
+  ASSERT_TRUE(deliverCatalog(layer, catalogOf({f.keep, f.drop}, 200)));
+
+  EXPECT_EQ(layer->residentTileCount(), std::size_t(2));
+  EXPECT_EQ(layer->overviewTileCount(), before);
+  for(const gggs::GridIndex& a : f.shared)
+  {
+    const SonarLiveTile* tile = layer->overviewTileForTest(a);
+    ASSERT_NE(tile, nullptr) << a;
+    // Both contributions still folded in — nothing was rebuilt or thrown away.
+    EXPECT_GT(finiteCellCount(*tile), std::size_t(0)) << a;
+    EXPECT_GT(cellsUnequalTo(*tile, kKeepValue), std::size_t(0)) << a;
+  }
+  for(const gggs::GridIndex& a : f.drop_only)
+    EXPECT_TRUE(QFileInfo::exists(f.paths.overviewPath(a))) << a;
+}
+
+// Prune-gate parity: a generation_time of 0 (un-stamped / sim-time-0 catalog) disables
+// prune-on-absence in the reconciler, because no held version can be strictly older
+// than 0. The pyramid sweep must honour the same gate — otherwise an un-stamped catalog
+// would delete the whole pyramid while every fine tile stayed exactly where it was.
+TEST(SonarLiveOverviewPrune, UnstampedCatalogDoesNotSweepThePyramid)
+{
+  QTemporaryDir cache;
+  ASSERT_TRUE(cache.isValid());
+  useCache(cache.path());
+
+  const QString ns = "/overview_unstamped_test";
+  const Fixture f = makeFixture(cache.path(), ns);
+
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  auto* layer = new SonarLiveCacheLayer(layers, nullptr, ns);
+  layer->enableLiveCoverage();
+  const std::size_t before = layer->overviewTileCount();
+
+  ASSERT_TRUE(deliverCatalog(layer, catalogOf({f.keep}, 0)));
+
+  EXPECT_EQ(layer->residentTileCount(), std::size_t(2));   // reconciler pruned nothing
+  EXPECT_EQ(layer->overviewTileCount(), before);
+  for(const gggs::GridIndex& a : f.drop_only)
+  {
+    EXPECT_NE(layer->overviewTileForTest(a), nullptr) << a;
+    EXPECT_TRUE(QFileInfo::exists(f.paths.overviewPath(a))) << a;
+  }
+}
+
+int main(int argc, char** argv)
+{
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QApplication app(argc, argv);
+  QCoreApplication::setOrganizationName("camp_test");
+  QCoreApplication::setApplicationName("test_sonar_live_overview_prune");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_sonar_live_placeholder_draw.cpp
+++ b/test/test_sonar_live_placeholder_draw.cpp
@@ -1,0 +1,471 @@
+// [field 2026-08-27] Headless regression test: coarse overview data may be drawn ONLY
+// as a placeholder for a fine tile that is known to exist and has not loaded, clipped
+// to that fine tile's own footprint (ADR-0010 D5).
+//
+// The draw list used to be "every resident overview, coarse->fine, then the fine tiles
+// on top", licensed by the camp#160 premise that "where a fine tile is present it fully
+// covers its parent". That premise is false — a child covers a QUARTER of its parent —
+// so wherever fine coverage is sparse (most of a survey in progress) the coarse
+// ancestors painted through, over the chart. Measured on pandy during the BizzyBoat
+// deployment: every cached tile is 960x960 cells at every level, so a level-0 cell is
+// ~667 x 926 m of the MEAN of everything folded beneath it. The operator reported a
+// solid ~650 m block over a good portion of the survey area, and the apex is exactly
+// what kApexProtectLevel keeps resident forever.
+//
+// What is pinned here:
+//   * NothingCoarseWhileTheFineTilesAreResident  the reported defect: with the fine
+//                                data loaded, no overview contributes at all;
+//   * PlaceholderClippedToItsOwnFootprint        a catalogued, non-resident fine tile
+//                                IS covered by coarse data — sampled through a strict
+//                                sub-rect of the overview, over the fine tile's extent
+//                                and no further. Drawing the full coarse extent is
+//                                precisely the bug, so the clip bound is asserted;
+//   * ZoomedOutCoverageSurvivesEviction          the ADR-0010 D1 guarantee: with every
+//                                fine tile evicted, a whole-survey view still shows
+//                                each surveyed footprint (and here with no catalog at
+//                                all, so evicted_fine_indices_ carries it alone);
+//   * UnsurveyedWaterDrawsNothing                water inside the apex's extent that no
+//                                fine tile ever covered gets nothing, at either zoom —
+//                                the apex's own extent is 8 degrees of mostly untouched
+//                                ocean.
+//
+// Offscreen QApplication + Map harness as test_sonar_live_overview_prune / _eviction:
+// GL-free (renderImage() is never called, so no texture is ever uploaded — planDraw()
+// resolves the selection without touching GL) and ROS-free (null Node -> no
+// subscription; handleCatalog is invoked by name exactly as the ROS callback's
+// GUI-thread marshal does).
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QDir>
+#include <QGeoCoordinate>
+#include <QFile>
+#include <QMetaObject>
+#include <QRectF>
+#include <QSettings>
+#include <QTemporaryDir>
+#include <QUrl>
+
+#include "marine_autonomy/gggs.h"
+#include "marine_interfaces/msg/sonar_visualization_tile.hpp"
+#include "marine_interfaces/msg/tile_catalog.hpp"
+#include "marine_interfaces/msg/visualization_band.hpp"
+
+#include "map/map.h"
+#include "map/layer_list.h"
+#include "map_view/web_mercator.h"
+#include "ros/live_coverage/sonar_live_cache_layer.h"
+#include "ros/live_coverage/sonar_live_tile.h"
+
+namespace mi = marine_interfaces::msg;
+using camp::map::Map;
+using camp::ros::live_coverage::SonarLiveCacheLayer;
+using camp::ros::live_coverage::SonarLiveTile;
+using camp::ros::live_coverage::tileIndexFromGridIndex;
+using DrawItem = SonarLiveCacheLayer::DrawItem;
+
+namespace
+{
+
+constexpr int kLevel = 10;
+constexpr int kEdge = 8;
+constexpr std::int16_t kDepthBase = 300;   // 3.00 m
+
+QString sanitizeNamespace(const QString& ns)
+{
+  return QString::fromLatin1(QUrl::toPercentEncoding(ns));
+}
+
+// A uniform full-tile INT16 "depth" patch (value = base * 0.01) for @p grid.
+mi::SonarVisualizationTile makeUniformDepth(const gggs::GridIndex& grid, std::int16_t base)
+{
+  mi::SonarVisualizationTile msg;
+  msg.header.stamp.sec = 100;
+  msg.header.frame_id = "gggs";
+  msg.index = tileIndexFromGridIndex(grid);
+  msg.width = kEdge;
+  msg.height = kEdge;
+  msg.window_col = 0;
+  msg.window_row = 0;
+  msg.window_width = kEdge;
+  msg.window_height = kEdge;
+
+  mi::VisualizationBand band;
+  band.name = "depth";
+  band.dtype = mi::VisualizationBand::INT16;
+  band.scale = 0.01;
+  band.offset = 0.0;
+  band.nodata = -32768.0;
+  for(int i = 0; i < kEdge * kEdge; ++i)
+  {
+    band.data.push_back(static_cast<std::uint8_t>(base & 0xff));
+    band.data.push_back(static_cast<std::uint8_t>((base >> 8) & 0xff));
+  }
+  msg.bands.push_back(band);
+  return msg;
+}
+
+QString stemOf(const gggs::GridIndex& index)
+{
+  return QString("%1_%2_%3")
+    .arg(static_cast<int>(index.level()))
+    .arg(index.row())
+    .arg(index.column());
+}
+
+// Every strict ancestor of @p index, finest first, up to level 0.
+std::vector<gggs::GridIndex> ancestorChain(const gggs::GridIndex& index)
+{
+  std::vector<gggs::GridIndex> chain;
+  for(gggs::GridIndex a = gggs::parent(index); a.valid(); a = gggs::parent(a))
+    chain.push_back(a);
+  return chain;
+}
+
+struct CachePaths
+{
+  QString fine;
+  QString overviews;
+
+  QString finePath(const gggs::GridIndex& index) const
+  {
+    return QDir(fine).filePath(stemOf(index) + ".tif");
+  }
+};
+
+// Seed the on-disk cache the way a live session would have left it: each fine tile at
+// the cache-dir root plus the full overview chain it folds into, mirroring
+// foldIntoParent() (fold the fine tile into its parent, then the WHOLE parent into the
+// grandparent, up to level 0).
+CachePaths seedCache(const QString& cache_root, const QString& ns,
+                     const std::vector<gggs::GridIndex>& fine_tiles)
+{
+  CachePaths paths;
+  paths.fine = QDir(cache_root).filePath(sanitizeNamespace(ns));
+  paths.overviews = QDir(paths.fine).filePath("overviews");
+  EXPECT_TRUE(QDir().mkpath(paths.fine));
+  EXPECT_TRUE(QDir().mkpath(paths.overviews));
+
+  std::map<gggs::GridIndex, SonarLiveTile> overviews;
+  for(const gggs::GridIndex& grid : fine_tiles)
+  {
+    SonarLiveTile tile(grid, kEdge, kEdge);
+    tile.applyPatch(makeUniformDepth(grid, kDepthBase));
+    EXPECT_TRUE(tile.writeToGeoTiff(paths.finePath(grid).toStdString()));
+
+    const SonarLiveTile* child = &tile;
+    for(const gggs::GridIndex& ancestor : ancestorChain(grid))
+    {
+      auto it = overviews.find(ancestor);
+      if(it == overviews.end())
+        it = overviews.emplace(ancestor, SonarLiveTile(ancestor, kEdge, kEdge)).first;
+      it->second.foldChild(*child);
+      child = &it->second;
+    }
+  }
+  for(const auto& [index, tile] : overviews)
+    EXPECT_TRUE(tile.writeToGeoTiff(
+      QDir(paths.overviews).filePath(stemOf(index) + ".tif").toStdString()));
+  return paths;
+}
+
+mi::TileCatalog catalogOf(const std::vector<gggs::GridIndex>& indices, std::int32_t stamp_sec)
+{
+  mi::TileCatalog catalog;
+  catalog.header.stamp.sec = stamp_sec;
+  for(const gggs::GridIndex& index : indices)
+  {
+    mi::TileCatalogEntry entry;
+    entry.index = tileIndexFromGridIndex(index);
+    entry.version.sec = 150;
+    catalog.entries.push_back(entry);
+  }
+  return catalog;
+}
+
+bool deliverCatalog(SonarLiveCacheLayer* layer, const mi::TileCatalog& catalog)
+{
+  return QMetaObject::invokeMethod(layer, "handleCatalog", Qt::DirectConnection,
+                                   Q_ARG(marine_interfaces::msg::TileCatalog, catalog));
+}
+
+// The Web-Mercator scene rect of a GGGS index — the same extent math the layer's clip
+// test uses, so a test clip means exactly what the draw path means by it.
+QRectF sceneRectOf(const gggs::GridIndex& index)
+{
+  const QPointF lo = web_mercator::geoToMap(
+    QGeoCoordinate(index.southLatitude(), index.westLongitude()));
+  const QPointF hi = web_mercator::geoToMap(
+    QGeoCoordinate(index.northLatitude(), index.eastLongitude()));
+  return QRectF(lo, hi).normalized();
+}
+
+// Two well-separated fine tiles at the survey's level (~0.15 deg apart in latitude, so
+// they share only the coarse ancestors) and the cache seeded from them.
+struct Fixture
+{
+  gggs::GridIndex a;
+  gggs::GridIndex b;
+  CachePaths paths;
+};
+
+Fixture makeFixture(const QString& cache_root, const QString& ns)
+{
+  Fixture f;
+  const gggs::Level level(kLevel);
+  f.a = level.gridIndex(43.05, -70.55);
+  f.b = level.gridIndex(43.20, -70.55);
+  EXPECT_TRUE(f.a.valid());
+  EXPECT_TRUE(f.b.valid());
+  EXPECT_FALSE(f.a == f.b);
+  f.paths = seedCache(cache_root, ns, {f.a, f.b});
+  return f;
+}
+
+// Point the layer at the temp cache with @p budget_bytes of resident-footprint budget
+// (0 disables eviction entirely, so the tests always pass a real number).
+void useCache(const QString& cache_root, std::size_t budget_bytes)
+{
+  QSettings().clear();
+  QSettings().setValue("LiveTileCache/cache_dir", cache_root);
+  QSettings().setValue("LiveTileCache/max_vram_bytes", qulonglong(budget_bytes));
+}
+
+constexpr std::size_t kTileBytes = std::size_t(kEdge) * kEdge * sizeof(float);
+
+std::vector<DrawItem> placeholdersOf(const std::vector<DrawItem>& plan)
+{
+  std::vector<DrawItem> out;
+  for(const DrawItem& item : plan)
+    if(item.placeholder)
+      out.push_back(item);
+  return out;
+}
+
+const DrawItem* footprintIn(const std::vector<DrawItem>& plan, const gggs::GridIndex& index)
+{
+  for(const DrawItem& item : plan)
+    if(item.footprint == index)
+      return &item;
+  return nullptr;
+}
+
+}  // namespace
+
+// The reported defect. With the fine tiles resident there is nothing for a coarse
+// placeholder to stand in for, so no overview may contribute — not the level-0 apex
+// (a ~650 m block of the mean of everything beneath it), not any other level. Before
+// this change EVERY resident overview level was appended to the draw list at EVERY
+// zoom, and the apex is resident by design (kApexProtectLevel).
+TEST(SonarLivePlaceholderDraw, NothingCoarseWhileTheFineTilesAreResident)
+{
+  QTemporaryDir cache;
+  ASSERT_TRUE(cache.isValid());
+  useCache(cache.path(), 1000 * kTileBytes);   // generous: nothing is evicted
+
+  const QString ns = "/placeholder_resident_test";
+  const Fixture f = makeFixture(cache.path(), ns);
+
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  auto* layer = new SonarLiveCacheLayer(layers, nullptr, ns);
+  layer->enableLiveCoverage();
+
+  ASSERT_EQ(layer->residentTileCount(), std::size_t(2));
+  // Not vacuous: the pyramid IS resident, apex included, and would have been drawn.
+  ASSERT_GT(layer->overviewTileCount(), std::size_t(0));
+  gggs::GridIndex apex = f.a;
+  while(gggs::parent(apex).valid())
+    apex = gggs::parent(apex);
+  ASSERT_NE(layer->overviewTileForTest(apex), nullptr)
+    << "the apex is resident by design (kApexProtectLevel) — it is what used to draw";
+  ASSERT_TRUE(deliverCatalog(layer, catalogOf({f.a, f.b}, 200)));
+  ASSERT_EQ(layer->residentTileCount(), std::size_t(2)) << "the catalog kept both";
+
+  // Survey zoom: the viewport is one fine tile.
+  const std::vector<DrawItem> plan = layer->planDraw(sceneRectOf(f.a));
+  EXPECT_TRUE(placeholdersOf(plan).empty())
+    << "coarse data drawn while the fine tile it would stand in for is loaded";
+  ASSERT_EQ(plan.size(), std::size_t(1));
+  EXPECT_TRUE(plan.front().footprint == f.a);
+  EXPECT_TRUE(plan.front().source == f.a);
+  // A resident tile samples its whole texture — the RasterFieldItem default, which is
+  // what keeps every other caller of the shared renderer unchanged.
+  EXPECT_FLOAT_EQ(plan.front().u0, 0.0f);
+  EXPECT_FLOAT_EQ(plan.front().v0, 0.0f);
+  EXPECT_FLOAT_EQ(plan.front().u1, 1.0f);
+  EXPECT_FLOAT_EQ(plan.front().v1, 1.0f);
+}
+
+// A catalogued fine tile that is NOT resident is covered by coarse data — sampled out
+// of its finest resident ancestor through a strict sub-rect, and painted over the fine
+// tile's own footprint. Painting the ancestor's whole extent instead is the bug, so
+// both halves are asserted: the extent painted, and the texture window.
+TEST(SonarLivePlaceholderDraw, PlaceholderClippedToItsOwnFootprint)
+{
+  QTemporaryDir cache;
+  ASSERT_TRUE(cache.isValid());
+  useCache(cache.path(), 1000 * kTileBytes);
+
+  const QString ns = "/placeholder_clip_test";
+  const Fixture f = makeFixture(cache.path(), ns);
+  // Tile b's fine copy is gone (the boat has it, we don't yet); its folded coverage
+  // survives in the pyramid, which is exactly the placeholder case.
+  ASSERT_TRUE(QFile::remove(f.paths.finePath(f.b)));
+
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  auto* layer = new SonarLiveCacheLayer(layers, nullptr, ns);
+  layer->enableLiveCoverage();
+  ASSERT_EQ(layer->residentTileCount(), std::size_t(1));
+
+  // The boat holds both, so b is known to exist.
+  ASSERT_TRUE(deliverCatalog(layer, catalogOf({f.a, f.b}, 200)));
+
+  const std::vector<DrawItem> plan = layer->planDraw(sceneRectOf(f.b));
+  const std::vector<DrawItem> placeholders = placeholdersOf(plan);
+  ASSERT_EQ(placeholders.size(), std::size_t(1))
+    << "a known-but-unloaded tile must be covered by coarse data";
+  const DrawItem& item = placeholders.front();
+
+  EXPECT_TRUE(item.footprint == f.b) << "painted over the missing tile's extent";
+  const gggs::GridIndex expected_source = gggs::parent(f.b);
+  EXPECT_TRUE(item.source == expected_source)
+    << "the FINEST resident ancestor supplies the pixels";
+  ASSERT_NE(layer->overviewTileForTest(expected_source), nullptr);
+
+  // The clip bound. One level up is a 2x2 fold, so the window is exactly a quarter of
+  // the ancestor — a fine index NEVER covers the whole of a coarser tile.
+  EXPECT_LT(item.u1 - item.u0, 1.0f);
+  EXPECT_LT(item.v1 - item.v0, 1.0f);
+  EXPECT_FLOAT_EQ(item.u1 - item.u0, 0.5f);
+  EXPECT_FLOAT_EQ(item.v1 - item.v0, 0.5f);
+
+  // ...and it is the RIGHT quarter. Derived here from the geographic extents, which is
+  // an independent route to the same answer as the index arithmetic the layer uses
+  // (u west->east, v north->south, texture row 0 = north).
+  const double lon_span = expected_source.eastLongitude() - expected_source.westLongitude();
+  const double lat_span = expected_source.northLatitude() - expected_source.southLatitude();
+  ASSERT_GT(lon_span, 0.0);
+  ASSERT_GT(lat_span, 0.0);
+  EXPECT_NEAR(item.u0, (f.b.westLongitude() - expected_source.westLongitude()) / lon_span,
+              1e-5);
+  EXPECT_NEAR(item.u1, (f.b.eastLongitude() - expected_source.westLongitude()) / lon_span,
+              1e-5);
+  EXPECT_NEAR(item.v0, (expected_source.northLatitude() - f.b.northLatitude()) / lat_span,
+              1e-5);
+  EXPECT_NEAR(item.v1, (expected_source.northLatitude() - f.b.southLatitude()) / lat_span,
+              1e-5);
+
+  // The resident tile is untouched by any of this: it is outside this viewport, and it
+  // never gets a placeholder of its own.
+  EXPECT_EQ(footprintIn(plan, f.a), nullptr);
+}
+
+// ADR-0010 D1, the regression guard: evict every fine tile (the shed-load path) and a
+// whole-survey view must still show the surveyed area. No catalog is delivered here on
+// purpose — a warm start with the link down has only evicted_fine_indices_, and the
+// coverage must not depend on a catalog arriving.
+TEST(SonarLivePlaceholderDraw, ZoomedOutCoverageSurvivesEviction)
+{
+  QTemporaryDir cache;
+  ASSERT_TRUE(cache.isValid());
+  useCache(cache.path(), kTileBytes / 2);   // below one tile: everything sheds
+
+  const QString ns = "/placeholder_zoomout_test";
+  const Fixture f = makeFixture(cache.path(), ns);
+
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  auto* layer = new SonarLiveCacheLayer(layers, nullptr, ns);
+  layer->enableLiveCoverage();
+
+  ASSERT_EQ(layer->residentTileCount(), std::size_t(0)) << "warm-load must have shed";
+  ASSERT_EQ(layer->evictedFineCount(), std::size_t(2));
+
+  const QRectF survey = sceneRectOf(f.a).united(sceneRectOf(f.b));
+  const std::vector<DrawItem> plan = layer->planDraw(survey);
+  ASSERT_EQ(plan.size(), std::size_t(2)) << "a zoomed-out view lost its coverage";
+  for(const gggs::GridIndex& index : {f.a, f.b})
+  {
+    const DrawItem* item = footprintIn(plan, index);
+    ASSERT_NE(item, nullptr) << "no coverage at " << index;
+    EXPECT_TRUE(item->placeholder);
+    // Still clipped: the apex survives eviction (kApexProtectLevel) and is many levels
+    // up, so the window is a small fraction of it — never the whole coarse extent.
+    EXPECT_LT(item->u1 - item->u0, 1.0f);
+    EXPECT_LT(item->v1 - item->v0, 1.0f);
+    EXPECT_GT(item->u1, item->u0);
+    EXPECT_GT(item->v1, item->v0);
+    EXPECT_LT(static_cast<int>(item->source.level()), kLevel);
+  }
+}
+
+// Water inside the apex's own extent that no fine tile ever covered draws nothing, at
+// any zoom. A level-0 grid spans 8 degrees — the overwhelming majority of it is ocean
+// nobody surveyed, and painting a coarse cell's mean across it is what put a block over
+// the operator's chart.
+TEST(SonarLivePlaceholderDraw, UnsurveyedWaterDrawsNothing)
+{
+  QTemporaryDir cache;
+  ASSERT_TRUE(cache.isValid());
+  useCache(cache.path(), kTileBytes / 2);   // everything evicted: the apex is all there is
+
+  const QString ns = "/placeholder_unsurveyed_test";
+  const Fixture f = makeFixture(cache.path(), ns);
+
+  Map map;
+  camp::map::LayerList* layers = map.topLevelLayers();
+  ASSERT_NE(layers, nullptr);
+  auto* layer = new SonarLiveCacheLayer(layers, nullptr, ns);
+  layer->enableLiveCoverage();
+  ASSERT_TRUE(deliverCatalog(layer, catalogOf({f.a, f.b}, 200)));
+
+  // Unsurveyed water ~1.3 deg north of the survey, inside the SAME level-0 grid — so
+  // the apex tile really does span it, and the old draw path really did paint it.
+  const gggs::GridIndex empty_fine = gggs::Level(kLevel).gridIndex(44.5, -70.55);
+  ASSERT_TRUE(empty_fine.valid());
+  gggs::GridIndex apex = f.a;
+  while(gggs::parent(apex).valid())
+    apex = gggs::parent(apex);
+  ASSERT_EQ(static_cast<int>(apex.level()), 0);
+  ASSERT_NE(layer->overviewTileForTest(apex), nullptr) << "the apex must be resident";
+  gggs::GridIndex empty_apex = empty_fine;
+  while(gggs::parent(empty_apex).valid())
+    empty_apex = gggs::parent(empty_apex);
+  ASSERT_TRUE(empty_apex == apex) << "fixture: the empty area must be under the apex";
+
+  EXPECT_TRUE(layer->planDraw(sceneRectOf(empty_fine)).empty())
+    << "coarse data painted over water no fine tile ever covered";
+
+  // Zoomed out to the whole apex, the surveyed footprints appear and nothing else does:
+  // no drawn footprint reaches the unsurveyed area.
+  const std::vector<DrawItem> wide = layer->planDraw(sceneRectOf(apex));
+  EXPECT_FALSE(wide.empty());
+  const QRectF empty_rect = sceneRectOf(empty_fine);
+  for(const DrawItem& item : wide)
+    EXPECT_FALSE(sceneRectOf(item.footprint).intersects(empty_rect))
+      << "drew " << item.footprint << " over unsurveyed water";
+}
+
+int main(int argc, char** argv)
+{
+  qputenv("QT_QPA_PLATFORM", "offscreen");
+  QApplication app(argc, argv);
+  QCoreApplication::setOrganizationName("camp_test");
+  QCoreApplication::setApplicationName("test_sonar_live_placeholder_draw");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Imports the 2026-08-27 field commits from gitcloud. Part of
[rolker/camp#219](https://github.com/rolker/camp/issues/219); produced during the wrap-up of
deployment [rolker/unh_echoboats_project11#467](https://github.com/rolker/unh_echoboats_project11/issues/467).

Branched directly from `gitcloud/jazzy` so the original field SHAs are preserved. Not diverged; this
is a fast-forward.

## What's in it

Three commits reworking the live-coverage cache layer (+666 in `sonar_live_cache_layer.cpp`, +158 in
its header): catalog prune-on-absence propagated into the overview pyramid, coarse coverage drawn
only as a clipped placeholder where a tile is missing, and the catalog QoS change below.

## Reviewer attention: `532b6df` is the mirror of a workaround

It drops CAMP's `coverage_catalog` subscription to VOLATILE to match udp_bridge's republish. Unlike
its counterpart in `unh_marine_autonomy` (`1ffc459`), **this commit does not carry the "field
workaround, revert later" framing**, so on its own it reads as a settled fix. It is not one.

`cube_bathymetry` publishes the catalog `transient_local` deliberately for late joiners
(`cube_bathymetry_node.cpp:515`); the break is that udp_bridge downgrades durability when it
republishes, and a TRANSIENT_LOCAL subscriber cannot match a VOLATILE publisher. Where the fix
belongs was put to the operator during the #467 wrap-up and left open: *"I don't have an opinion on
1, I'd have to delve deeper into what was happening."*

CAMP masked this break for longer than the web renderer did, because it warm-loads a disk cache
while the renderer is memory-only.

Revert together with
[rolker/unh_marine_autonomy#363](https://github.com/rolker/unh_marine_autonomy/pull/363) once the
relay preserves producer durability.

## Test plan

Roughly 1,070 lines of new tests accompany the change:

- `test_sonar_live_overview_prune.cpp` (487 lines) — prune-on-absence into the overview pyramid
- `test_sonar_live_placeholder_draw.cpp` (471 lines) — clipped placeholder for a missing tile
- `test_raster_gl_renderer.cpp` (68 lines) — renderer changes
- `test_sonar_live_catalog_qos.cpp` (44 lines) — the catalog QoS subscription

Field-verified on pandy during the 2026-08-27 Appledore deployment; the operator confirmed live
coverage rendering after the change.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 5 (1M context)`
